### PR TITLE
feat: improve scripts based on CTracer validation findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Shared script utilities module (`scan_common.py`) for project root detection, file discovery, API table loading.
 - Test infrastructure with TempExtension helper, 4 C code fixtures, 1 setup.py template, and 80+ tests.
 
+### Enhanced
+- `scan_null_checks.py`: added `deref_macro_on_unchecked` finding type — detects dereference-like macros (PyBytes_AS_STRING, PyList_GET_ITEM, etc.) called on unchecked NULL-able values.
+- `scan_type_slots.py`: added `dealloc_missing_xdecref` finding type — detects PyObject* struct members not cleaned up in tp_dealloc.
+- `scan_common.py`: `find_assigned_variable()` now skips past ALL_CAPS macro wrappers (e.g., `STATS(x = PyDict_New())`).
+- New `scan_version_compat.py` script: detects removed/deprecated API usage, missing version guards, and dead compatibility code.
+- `deprecated_apis.json`: added `removed_in` and `version_added` fields, plus entries for PyObject_CallObject, PyEval_CallObject, PyEval_CallObjectWithKeywords.
+- `version-compat-scanner` agent now uses `scan_version_compat.py` for script-assisted triage.
+
 ### Fixed
 - `_check_return_without_exception` false negative: now only suppresses finding when error return is inside a NULL-check block for an exception-setting API.
 - `_check_exception_clobbering` false positive: no longer flags `PyErr_SetString` and other exception-setting APIs as clobbering.

--- a/plugins/cext-review-toolkit/agents/version-compat-scanner.md
+++ b/plugins/cext-review-toolkit/agents/version-compat-scanner.md
@@ -20,7 +20,23 @@ Python's C API changes across versions:
 
 ## Analysis Approach
 
-This agent performs **qualitative analysis** without a dedicated script. Use Grep and file reading to examine the codebase, guided by `<plugin_root>/data/deprecated_apis.json`.
+### Phase 1: Script-Assisted Triage
+
+Run the version compatibility scanner to get structured findings:
+
+```bash
+python <plugin_root>/scripts/scan_version_compat.py [scope] --min-python 3.9
+```
+
+Key fields:
+- `findings[].type`: removed_api_usage, deprecated_api_usage, missing_version_guard, dead_version_guard
+- `findings[].api`: which API is affected
+- `findings[].confidence`: high or medium
+- `min_python`: the detected or specified minimum Python version
+
+### Phase 2: Qualitative Analysis
+
+Beyond the script findings, perform deeper analysis using Grep and file reading, guided by `<plugin_root>/data/deprecated_apis.json`.
 
 ### Step 1: Determine Target Python Versions
 

--- a/plugins/cext-review-toolkit/data/deprecated_apis.json
+++ b/plugins/cext-review-toolkit/data/deprecated_apis.json
@@ -3,92 +3,140 @@
     {
       "name": "PyModule_AddObject",
       "deprecated_since": "3.10",
+      "removed_in": null,
       "replacement": "PyModule_AddObjectRef",
       "note": "Steals reference on success only (pre-3.10). AddObjectRef does not steal."
     },
     {
       "name": "PyUnicode_READY",
       "deprecated_since": "3.12",
+      "removed_in": "3.14",
       "replacement": null,
-      "note": "No-op since 3.12. Can be removed."
+      "note": "No-op since 3.12, macro removed in 3.14."
     },
     {
       "name": "Py_UNICODE",
       "deprecated_since": "3.3",
+      "removed_in": null,
       "replacement": "Py_UCS4 or wchar_t",
       "note": "Type deprecated since 3.3."
     },
     {
       "name": "PyUnicode_AS_UNICODE",
       "deprecated_since": "3.3",
+      "removed_in": null,
       "replacement": "PyUnicode_AsWideCharString",
       "note": "Returns deprecated Py_UNICODE buffer."
     },
     {
       "name": "PyUnicode_AsUnicode",
       "deprecated_since": "3.3",
+      "removed_in": null,
       "replacement": "PyUnicode_AsWideCharString",
       "note": "Returns deprecated Py_UNICODE buffer."
     },
     {
       "name": "PyUnicode_GET_SIZE",
       "deprecated_since": "3.3",
+      "removed_in": null,
       "replacement": "PyUnicode_GET_LENGTH",
       "note": "Use GET_LENGTH for actual character count."
     },
     {
       "name": "PyUnicode_GetSize",
       "deprecated_since": "3.3",
+      "removed_in": null,
       "replacement": "PyUnicode_GetLength",
       "note": "Use GetLength for actual character count."
     },
     {
       "name": "PyEval_InitThreads",
       "deprecated_since": "3.7",
+      "removed_in": null,
       "replacement": null,
       "note": "No-op since 3.7. Can be removed."
     },
     {
       "name": "PyCFunction_Call",
       "deprecated_since": "3.9",
+      "removed_in": "3.13",
       "replacement": "PyObject_Call",
       "note": "Use the generic call interface."
     },
     {
       "name": "PyOS_AfterFork",
       "deprecated_since": "3.7",
+      "removed_in": null,
       "replacement": "PyOS_AfterFork_Child",
       "note": "Renamed for clarity."
     },
     {
       "name": "PyObject_AsCharBuffer",
       "deprecated_since": "3.0",
+      "removed_in": null,
       "replacement": "PyObject_GetBuffer with PyBUF_SIMPLE",
       "note": "Old buffer protocol."
     },
     {
       "name": "PyObject_AsReadBuffer",
       "deprecated_since": "3.0",
+      "removed_in": null,
       "replacement": "PyObject_GetBuffer with PyBUF_SIMPLE",
       "note": "Old buffer protocol."
     },
     {
       "name": "PyObject_AsWriteBuffer",
       "deprecated_since": "3.0",
+      "removed_in": null,
       "replacement": "PyObject_GetBuffer with PyBUF_WRITABLE",
       "note": "Old buffer protocol."
     },
     {
       "name": "Py_TRASHCAN_SAFE_BEGIN",
       "deprecated_since": "3.11",
+      "removed_in": null,
       "replacement": "Py_TRASHCAN_BEGIN",
       "note": "Renamed macro."
     },
     {
       "name": "Py_TRASHCAN_SAFE_END",
       "deprecated_since": "3.11",
+      "removed_in": null,
       "replacement": "Py_TRASHCAN_END",
       "note": "Renamed macro."
+    },
+    {
+      "name": "PyObject_CallObject",
+      "deprecated_since": "3.9",
+      "removed_in": "3.15",
+      "replacement": "PyObject_CallNoArgs (no args) or PyObject_Call",
+      "note": "Use PyObject_CallNoArgs for zero-arg calls, PyObject_Call for general case."
+    },
+    {
+      "name": "PyEval_CallObject",
+      "deprecated_since": "3.9",
+      "removed_in": "3.13",
+      "replacement": "PyObject_Call",
+      "note": "Use the generic call interface."
+    },
+    {
+      "name": "PyEval_CallObjectWithKeywords",
+      "deprecated_since": "3.9",
+      "removed_in": "3.13",
+      "replacement": "PyObject_Call",
+      "note": "Use the generic call interface."
     }
-  ]
+  ],
+  "version_added": {
+    "PyModule_AddObjectRef": "3.10",
+    "PyType_FromModuleAndSpec": "3.10",
+    "Py_NewRef": "3.10",
+    "Py_XNewRef": "3.10",
+    "PyFrame_GetBack": "3.9",
+    "PyObject_CallNoArgs": "3.9",
+    "PyType_GetModuleByDef": "3.11",
+    "PyErr_GetRaisedException": "3.12",
+    "PyDict_GetItemRef": "3.13",
+    "Py_IsFinalizing": "3.13"
+  }
 }

--- a/plugins/cext-review-toolkit/scripts/scan_common.py
+++ b/plugins/cext-review-toolkit/scripts/scan_common.py
@@ -98,6 +98,14 @@ def find_assigned_variable(call_node, source_bytes: bytes) -> str | None:
             left = node.child_by_field_name("left")
             if left:
                 return get_node_text(left, source_bytes)
+        # Skip past macro wrappers (ALL_CAPS function calls that wrap assignments)
+        if node.type == "call_expression":
+            func = node.child_by_field_name("function")
+            if func:
+                func_text = get_node_text(func, source_bytes)
+                if func_text.isupper():
+                    node = node.parent
+                    continue
         if node.type in ("expression_statement", "declaration",
                           "compound_statement"):
             break

--- a/plugins/cext-review-toolkit/scripts/scan_null_checks.py
+++ b/plugins/cext-review-toolkit/scripts/scan_null_checks.py
@@ -25,6 +25,28 @@ from scan_common import (
 )
 
 
+# Macros that dereference their argument — crash if NULL.
+_DEREF_MACROS = {
+    "PyBytes_AS_STRING", "PyBytes_GET_SIZE",
+    "PyByteArray_AS_STRING", "PyByteArray_GET_SIZE",
+    "PyList_GET_ITEM", "PyList_GET_SIZE", "PyList_SET_ITEM",
+    "PyTuple_GET_ITEM", "PyTuple_GET_SIZE", "PyTuple_SET_ITEM",
+    "PyUnicode_GET_LENGTH", "PyUnicode_READ_CHAR",
+    "PyUnicode_DATA", "PyUnicode_READ",
+    "PyFloat_AS_DOUBLE",
+    "PySequence_Fast_GET_ITEM", "PySequence_Fast_GET_SIZE",
+    "PyWeakref_GET_OBJECT",
+    "PyCell_GET", "PyCell_SET",
+    "Py_SIZE", "Py_TYPE", "Py_REFCNT",
+}
+
+# APIs that return NULL on encoding/conversion failure.
+_NULLABLE_CONVERSION_APIS = {
+    "PyUnicode_AsASCIIString", "PyUnicode_AsUTF8String",
+    "PyUnicode_AsEncodedString", "PyUnicode_AsUTF8AndSize",
+    "PyObject_GetAttr", "PyObject_GetAttrString",
+}
+
 _ALLOC_APIS = {
     "PyMem_Malloc", "PyMem_Calloc", "PyMem_Realloc",
     "PyObject_Malloc", "PyObject_Calloc", "PyObject_Realloc",
@@ -131,6 +153,72 @@ def _check_deref_before_check(func, source_bytes, api_tables):
     return findings
 
 
+def _var_in_text(var: str, text: str) -> bool:
+    """Check if a variable name appears as a word in text."""
+    return bool(re.search(r'\b' + re.escape(var) + r'\b', text))
+
+
+def _check_deref_macro_on_unchecked(func, source_bytes, api_tables):
+    """Find dereference-like macros called on potentially-NULL values."""
+    findings = []
+    body = func["body_node"]
+    new_ref_apis = set(api_tables["new_ref_apis"])
+    nullable_apis = new_ref_apis | _NULLABLE_CONVERSION_APIS | _BORROWED_NULL_APIS
+
+    all_calls = find_calls_in_scope(body, source_bytes)
+    all_calls.sort(key=lambda c: c["start_byte"])
+
+    # Track variables assigned from nullable APIs.
+    nullable_vars: dict[str, tuple[str, int, int]] = {}
+    for call in all_calls:
+        if call["function_name"] not in nullable_apis:
+            continue
+        var = find_assigned_variable(call["node"], source_bytes)
+        if var:
+            nullable_vars[var] = (
+                call["function_name"], call["start_line"], call["start_byte"])
+
+    # Check if any deref macro is called with a nullable var
+    # without an intervening NULL check.
+    body_text = get_node_text(body, source_bytes)
+
+    for call in all_calls:
+        if call["function_name"] not in _DEREF_MACROS:
+            continue
+
+        args_text = call["arguments_text"]
+        for var, (api, api_line, api_byte) in nullable_vars.items():
+            if not _var_in_text(var, args_text):
+                continue
+
+            between_text = body_text[
+                api_byte - body.start_byte:call["start_byte"] - body.start_byte]
+            has_null_check = bool(re.search(
+                r'\bif\s*\(\s*' + re.escape(var) + r'\s*==\s*NULL|'
+                r'if\s*\(\s*!\s*' + re.escape(var) + r'\b|'
+                r'if\s*\(\s*' + re.escape(var) + r'\s*!=\s*NULL',
+                between_text
+            ))
+
+            if not has_null_check:
+                findings.append({
+                    "type": "deref_macro_on_unchecked",
+                    "file": "",
+                    "function": func["name"],
+                    "line": call["start_line"],
+                    "confidence": "high",
+                    "detail": (f"{call['function_name']}({var}) at line "
+                               f"{call['start_line']} — '{var}' from "
+                               f"{api}() (line {api_line}) may be NULL"),
+                    "macro": call["function_name"],
+                    "variable": var,
+                    "source_api": api,
+                    "source_line": api_line,
+                })
+
+    return findings
+
+
 def _check_unchecked_pyarg_parse(func, source_bytes, api_tables):
     """Find unchecked PyArg_ParseTuple calls."""
     findings = []
@@ -197,6 +285,7 @@ def analyze(target: str, *, max_files: int = 0) -> dict:
             total_functions += 1
             for checker in (_check_unchecked_alloc,
                             _check_deref_before_check,
+                            _check_deref_macro_on_unchecked,
                             _check_unchecked_pyarg_parse):
                 for f in checker(func, source_bytes, api_tables):
                     f["file"] = rel

--- a/plugins/cext-review-toolkit/scripts/scan_type_slots.py
+++ b/plugins/cext-review-toolkit/scripts/scan_type_slots.py
@@ -138,6 +138,56 @@ def _check_dealloc(type_info: dict, functions: list[dict],
     return findings
 
 
+def _check_dealloc_completeness(type_info: dict, functions: list[dict],
+                                 tree, source_bytes: bytes):
+    """Check that dealloc XDECREF's all PyObject* struct members."""
+    findings = []
+    dealloc_name = type_info.get("dealloc_func")
+    struct_name = type_info.get("struct_name")
+
+    if not dealloc_name or not struct_name:
+        return findings
+
+    dealloc_name = re.sub(r'\([^)]*\)\s*', '', dealloc_name).strip()
+    dealloc_func = _find_func_by_name(functions, dealloc_name)
+    if not dealloc_func:
+        return findings
+
+    members = find_struct_members(tree, source_bytes, struct_name)
+    pyobj_members = [m for m in members if m["is_pyobject"]]
+
+    if not pyobj_members:
+        return findings
+
+    dealloc_body = strip_comments(dealloc_func["body"])
+
+    for member in pyobj_members:
+        name = member["name"]
+        patterns = [
+            rf'Py_XDECREF\s*\([^)]*->\s*{re.escape(name)}\s*\)',
+            rf'Py_DECREF\s*\([^)]*->\s*{re.escape(name)}\s*\)',
+            rf'Py_CLEAR\s*\([^)]*->\s*{re.escape(name)}\s*\)',
+            rf'Py_SETREF\s*\([^)]*->\s*{re.escape(name)}\s*,',
+        ]
+        cleaned = any(re.search(p, dealloc_body) for p in patterns)
+
+        if not cleaned:
+            findings.append({
+                "type": "dealloc_missing_xdecref",
+                "file": "",
+                "function": dealloc_name,
+                "line": dealloc_func["start_line"],
+                "confidence": "high",
+                "detail": (f"tp_dealloc '{dealloc_name}' doesn't XDECREF/CLEAR "
+                           f"PyObject* member '{name}' of {struct_name} — "
+                           f"reference leak per object destruction"),
+                "type_name": type_info["name"],
+                "missing_member": name,
+            })
+
+    return findings
+
+
 def _check_traverse(type_info: dict, functions: list[dict],
                      tree, source_bytes: bytes):
     """Check tp_traverse visits all PyObject* members."""
@@ -368,6 +418,7 @@ def analyze(target: str, *, max_files: int = 0) -> dict:
             for checker_result in [
                 _check_dealloc(ti, functions, source_bytes,
                                source_bytes.decode("utf-8", errors="replace")),
+                _check_dealloc_completeness(ti, functions, tree, source_bytes),
                 _check_traverse(ti, functions, tree, source_bytes),
                 _check_richcompare(ti, functions, source_bytes),
                 _check_gc_flag(ti),

--- a/plugins/cext-review-toolkit/scripts/scan_version_compat.py
+++ b/plugins/cext-review-toolkit/scripts/scan_version_compat.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Scan C extension code for version compatibility issues.
+
+Checks API usage against known deprecated and removed APIs,
+detects missing version guards, and finds dead compatibility code.
+
+Usage:
+    python scan_version_compat.py [path] [--max-files N] [--min-python 3.9]
+"""
+
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from tree_sitter_utils import (
+    parse_bytes, extract_functions, find_calls_in_scope,
+    get_node_text, strip_comments,
+)
+from scan_common import find_project_root, discover_c_files
+
+_DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+
+
+def _load_deprecated_apis() -> dict:
+    """Load deprecated/removed API data."""
+    try:
+        with open(_DATA_DIR / "deprecated_apis.json", encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        print(json.dumps({"error": f"Failed to load deprecated_apis.json: {e}"}))
+        sys.exit(1)
+
+
+def _version_tuple(ver: str) -> tuple[int, int]:
+    """Parse '3.10' into (3, 10)."""
+    parts = ver.split(".")
+    return (int(parts[0]), int(parts[1]))
+
+
+def _version_hex(ver: str) -> int:
+    """Parse '3.10' into 0x030A0000."""
+    major, minor = _version_tuple(ver)
+    return (major << 24) | (minor << 16)
+
+
+def _check_removed_api(functions, source_bytes, api_data, min_python):
+    """Find calls to removed APIs."""
+    findings = []
+    min_ver = _version_tuple(min_python)
+    removed_apis = {}
+    for entry in api_data["deprecated"]:
+        removed_in = entry.get("removed_in")
+        if removed_in and _version_tuple(removed_in) <= min_ver:
+            removed_apis[entry["name"]] = entry
+
+    if not removed_apis:
+        return findings
+
+    api_names = set(removed_apis.keys())
+    for func in functions:
+        calls = find_calls_in_scope(func["body_node"], source_bytes,
+                                     api_names=api_names)
+        for call in calls:
+            entry = removed_apis[call["function_name"]]
+            # Check if the call is inside a version guard.
+            body_text = func["body"]
+            call_offset = call["start_byte"] - func["body_node"].start_byte
+            before_text = body_text[:call_offset]
+            # Simple check: is there a #if PY_VERSION_HEX guard?
+            if re.search(r'#\s*if\s+PY_VERSION_HEX', before_text):
+                continue
+
+            findings.append({
+                "type": "removed_api_usage",
+                "file": "",
+                "function": func["name"],
+                "line": call["start_line"],
+                "confidence": "high",
+                "detail": (f"{call['function_name']}() removed in Python "
+                           f"{entry['removed_in']}. "
+                           f"Replacement: {entry.get('replacement', 'none')}"),
+                "api": call["function_name"],
+                "removed_in": entry["removed_in"],
+                "replacement": entry.get("replacement"),
+            })
+
+    return findings
+
+
+def _check_deprecated_api(functions, source_bytes, api_data):
+    """Find calls to deprecated APIs."""
+    findings = []
+    deprecated_apis = {}
+    for entry in api_data["deprecated"]:
+        if entry.get("replacement"):
+            deprecated_apis[entry["name"]] = entry
+
+    if not deprecated_apis:
+        return findings
+
+    api_names = set(deprecated_apis.keys())
+    for func in functions:
+        calls = find_calls_in_scope(func["body_node"], source_bytes,
+                                     api_names=api_names)
+        for call in calls:
+            entry = deprecated_apis[call["function_name"]]
+            findings.append({
+                "type": "deprecated_api_usage",
+                "file": "",
+                "function": func["name"],
+                "line": call["start_line"],
+                "confidence": "medium",
+                "detail": (f"{call['function_name']}() deprecated since Python "
+                           f"{entry['deprecated_since']}. "
+                           f"Use {entry['replacement']} instead. "
+                           f"{entry.get('note', '')}"),
+                "api": call["function_name"],
+                "deprecated_since": entry["deprecated_since"],
+                "replacement": entry.get("replacement"),
+            })
+
+    return findings
+
+
+def _check_missing_version_guard(functions, source_bytes, api_data, min_python):
+    """Find newer API usage without version guards."""
+    findings = []
+    min_ver = _version_tuple(min_python)
+    version_added = api_data.get("version_added", {})
+
+    # Only flag APIs added after the minimum version.
+    newer_apis = {}
+    for api, ver in version_added.items():
+        if _version_tuple(ver) > min_ver:
+            newer_apis[api] = ver
+
+    if not newer_apis:
+        return findings
+
+    api_names = set(newer_apis.keys())
+    for func in functions:
+        calls = find_calls_in_scope(func["body_node"], source_bytes,
+                                     api_names=api_names)
+        for call in calls:
+            ver = newer_apis[call["function_name"]]
+            # Check for version guard.
+            body_text = func["body"]
+            call_offset = call["start_byte"] - func["body_node"].start_byte
+            before_text = body_text[:call_offset]
+            if re.search(r'#\s*if\s+PY_VERSION_HEX', before_text):
+                continue
+
+            findings.append({
+                "type": "missing_version_guard",
+                "file": "",
+                "function": func["name"],
+                "line": call["start_line"],
+                "confidence": "high",
+                "detail": (f"{call['function_name']}() requires Python {ver}+ "
+                           f"but min version is {min_python} — needs "
+                           f"#if PY_VERSION_HEX >= 0x{_version_hex(ver):08X} guard"),
+                "api": call["function_name"],
+                "added_in": ver,
+                "min_python": min_python,
+            })
+
+    return findings
+
+
+def _check_dead_version_guards(source_text, min_python):
+    """Find #if PY_VERSION_HEX < ... guards below minimum Python."""
+    findings = []
+    min_hex = _version_hex(min_python)
+
+    pattern = re.compile(
+        r'#\s*if\s+PY_VERSION_HEX\s*<\s*(0x[0-9A-Fa-f]+)')
+    for m in pattern.finditer(source_text):
+        guard_hex = int(m.group(1), 16)
+        if guard_hex <= min_hex:
+            line = source_text[:m.start()].count('\n') + 1
+            # Decode the version from hex.
+            major = (guard_hex >> 24) & 0xFF
+            minor = (guard_hex >> 16) & 0xFF
+            findings.append({
+                "type": "dead_version_guard",
+                "file": "",
+                "function": "(preprocessor)",
+                "line": line,
+                "confidence": "high",
+                "detail": (f"Version guard for Python < {major}.{minor} "
+                           f"is dead code — minimum supported is {min_python}"),
+                "guard_version": f"{major}.{minor}",
+                "guard_hex": m.group(1),
+                "min_python": min_python,
+            })
+
+    return findings
+
+
+def _detect_min_python(project_root: Path) -> str | None:
+    """Try to detect minimum Python version from project config."""
+    for config_file, pattern in [
+        ("setup.py", r'python_requires\s*=\s*["\']>=?\s*(\d+\.\d+)'),
+        ("pyproject.toml", r'requires-python\s*=\s*">=?\s*(\d+\.\d+)'),
+        ("setup.cfg", r'python_requires\s*=\s*>=?\s*(\d+\.\d+)'),
+    ]:
+        path = project_root / config_file
+        if path.is_file():
+            try:
+                content = path.read_text(encoding="utf-8", errors="replace")
+                m = re.search(pattern, content)
+                if m:
+                    return m.group(1)
+            except OSError:
+                continue
+    return None
+
+
+def analyze(target: str, *, max_files: int = 0,
+            min_python: str = "3.9") -> dict:
+    """Scan C files for version compatibility issues."""
+    target_path = Path(target).resolve()
+    project_root = find_project_root(target_path)
+    scan_root = target_path if target_path.is_dir() else target_path.parent
+
+    api_data = _load_deprecated_apis()
+
+    # Try to detect min_python from project config.
+    detected = _detect_min_python(project_root)
+    if detected:
+        min_python = detected
+
+    findings = []
+    total_functions = 0
+    files_analyzed = 0
+    skipped = []
+
+    for filepath in discover_c_files(scan_root, max_files=max_files):
+        try:
+            source_bytes = filepath.read_bytes()
+        except OSError as e:
+            skipped.append({"file": str(filepath), "reason": str(e)})
+            continue
+
+        tree = parse_bytes(source_bytes)
+        functions = extract_functions(tree, source_bytes)
+        source_text = source_bytes.decode("utf-8", errors="replace")
+
+        if not functions:
+            # Still check for dead version guards even without functions.
+            files_analyzed += 1
+            try:
+                rel = str(filepath.relative_to(project_root))
+            except ValueError:
+                rel = str(filepath)
+            for f in _check_dead_version_guards(source_text, min_python):
+                f["file"] = rel
+                findings.append(f)
+            continue
+
+        files_analyzed += 1
+        try:
+            rel = str(filepath.relative_to(project_root))
+        except ValueError:
+            rel = str(filepath)
+
+        total_functions += len(functions)
+
+        for checker_result in [
+            _check_removed_api(functions, source_bytes, api_data, min_python),
+            _check_deprecated_api(functions, source_bytes, api_data),
+            _check_missing_version_guard(functions, source_bytes,
+                                          api_data, min_python),
+            _check_dead_version_guards(source_text, min_python),
+        ]:
+            for f in checker_result:
+                f["file"] = rel
+                findings.append(f)
+
+    by_type = defaultdict(int)
+    by_confidence = defaultdict(int)
+    for f in findings:
+        by_type[f["type"]] += 1
+        by_confidence[f["confidence"]] += 1
+
+    result = {
+        "project_root": str(project_root),
+        "scan_root": str(scan_root),
+        "min_python": min_python,
+        "functions_analyzed": total_functions,
+        "files_analyzed": files_analyzed,
+        "findings": findings,
+        "summary": {
+            "total_findings": len(findings),
+            "by_type": dict(by_type),
+            "by_confidence": dict(by_confidence),
+        },
+    }
+    result["skipped_files"] = skipped
+    return result
+
+
+def main() -> None:
+    try:
+        max_files = 0
+        min_python = "3.9"
+        positional: list[str] = []
+        argv = sys.argv[1:]
+        i = 0
+        while i < len(argv):
+            if argv[i] == "--max-files" and i + 1 < len(argv):
+                max_files = int(argv[i + 1])
+                i += 2
+            elif argv[i] == "--min-python" and i + 1 < len(argv):
+                min_python = argv[i + 1]
+                i += 2
+            elif argv[i].startswith("--"):
+                i += 1
+            else:
+                positional.append(argv[i])
+                i += 1
+        target = positional[0] if positional else "."
+        result = analyze(target, max_files=max_files, min_python=min_python)
+        json.dump(result, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    except Exception as e:
+        json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_scan_null_checks.py
+++ b/tests/test_scan_null_checks.py
@@ -90,5 +90,54 @@ class TestScanNullChecks(unittest.TestCase):
             self.assertIn("summary", result)
 
 
+DEREF_MACRO_BUG = """\
+#include <Python.h>
+
+static PyObject *
+macro_deref_bug(PyObject *self, PyObject *args)
+{
+    PyObject *ascii = PyUnicode_AsASCIIString(self);
+    const char *s = PyBytes_AS_STRING(ascii);
+    return PyUnicode_FromString(s);
+}
+"""
+
+DEREF_MACRO_SAFE = """\
+#include <Python.h>
+
+static PyObject *
+macro_deref_safe(PyObject *self, PyObject *args)
+{
+    PyObject *ascii = PyUnicode_AsASCIIString(self);
+    if (ascii == NULL)
+        return NULL;
+    const char *s = PyBytes_AS_STRING(ascii);
+    Py_DECREF(ascii);
+    return PyUnicode_FromString(s);
+}
+"""
+
+
+class TestDerefMacroDetection(unittest.TestCase):
+    """Test dereference-like macro detection on unchecked values."""
+
+    def test_detects_deref_macro_on_unchecked(self):
+        """Detect PyBytes_AS_STRING on unchecked PyUnicode_AsASCIIString result."""
+        with TempExtension({"ext.c": DEREF_MACRO_BUG}) as root:
+            result = null_checks.analyze(str(root / "ext.c"))
+            deref = [f for f in result["findings"]
+                     if f["type"] == "deref_macro_on_unchecked"]
+            self.assertGreater(len(deref), 0)
+            self.assertEqual(deref[0]["macro"], "PyBytes_AS_STRING")
+
+    def test_no_finding_when_null_checked(self):
+        """No finding when the variable is NULL-checked before macro use."""
+        with TempExtension({"ext.c": DEREF_MACRO_SAFE}) as root:
+            result = null_checks.analyze(str(root / "ext.c"))
+            deref = [f for f in result["findings"]
+                     if f["type"] == "deref_macro_on_unchecked"]
+            self.assertEqual(len(deref), 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_scan_refcounts.py
+++ b/tests/test_scan_refcounts.py
@@ -133,5 +133,35 @@ class TestScanRefcounts(unittest.TestCase):
             self.assertIn("by_type", result["summary"])
 
 
+MACRO_WRAPPED = """\
+#include <Python.h>
+
+#define STATS(x) x
+
+static PyObject *
+macro_wrapped(PyObject *self, PyObject *args)
+{
+    PyObject *result;
+    STATS( result = PyDict_New() );
+    if (result == NULL)
+        return NULL;
+    return result;
+}
+"""
+
+
+class TestMacroWrapped(unittest.TestCase):
+    """Test handling of macro-wrapped variable names."""
+
+    def test_macro_wrapped_assignment(self):
+        """Variable name extracted correctly from STATS() macro wrapper."""
+        with TempExtension({"ext.c": MACRO_WRAPPED}) as root:
+            result = refcounts.analyze(str(root / "ext.c"))
+            for f in result["findings"]:
+                if "variable" in f:
+                    self.assertNotIn("STATS", f["variable"])
+                    self.assertNotIn("(", f["variable"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_scan_type_slots.py
+++ b/tests/test_scan_type_slots.py
@@ -147,5 +147,84 @@ class TestScanTypeSlots(unittest.TestCase):
             self.assertIn("summary", result)
 
 
+DEALLOC_INCOMPLETE = """\
+#include <Python.h>
+
+typedef struct {
+    PyObject_HEAD
+    PyObject *name;
+    PyObject *value;
+    PyObject *extra;
+} IncompleteObj;
+
+static void
+IncompleteObj_dealloc(IncompleteObj *self)
+{
+    Py_XDECREF(self->name);
+    Py_XDECREF(self->value);
+    /* BUG: self->extra not cleaned up */
+    Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
+static PyTypeObject IncompleteObjType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "test.IncompleteObj",
+    .tp_basicsize = sizeof(IncompleteObj),
+    .tp_dealloc = (destructor)IncompleteObj_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+};
+"""
+
+DEALLOC_COMPLETE = """\
+#include <Python.h>
+
+typedef struct {
+    PyObject_HEAD
+    PyObject *name;
+    PyObject *value;
+} CompleteObj;
+
+static void
+CompleteObj_dealloc(CompleteObj *self)
+{
+    Py_XDECREF(self->name);
+    Py_XDECREF(self->value);
+    Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
+static PyTypeObject CompleteObjType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "test.CompleteObj",
+    .tp_basicsize = sizeof(CompleteObj),
+    .tp_dealloc = (destructor)CompleteObj_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+};
+"""
+
+
+class TestDeallocCompleteness(unittest.TestCase):
+    """Test dealloc completeness checking."""
+
+    def test_detects_missing_xdecref_in_dealloc(self):
+        """Detect PyObject* member not XDECREF'd in dealloc."""
+        with TempExtension({"ext.c": DEALLOC_INCOMPLETE}) as root:
+            result = type_slots.analyze(str(root / "ext.c"))
+            missing = [f for f in result["findings"]
+                       if f["type"] == "dealloc_missing_xdecref"]
+            self.assertGreater(len(missing), 0)
+            names = [f["missing_member"] for f in missing]
+            self.assertIn("extra", names)
+            self.assertNotIn("name", names)
+            self.assertNotIn("value", names)
+
+    def test_complete_dealloc_no_finding(self):
+        """Complete dealloc produces no dealloc_missing_xdecref findings."""
+        with TempExtension({"ext.c": DEALLOC_COMPLETE}) as root:
+            result = type_slots.analyze(str(root / "ext.c"))
+            missing = [f for f in result["findings"]
+                       if f["type"] == "dealloc_missing_xdecref"]
+            self.assertEqual(len(missing), 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_scan_version_compat.py
+++ b/tests/test_scan_version_compat.py
@@ -1,0 +1,104 @@
+"""Tests for scan_version_compat.py — version compatibility scanning."""
+
+import unittest
+from helpers import import_script, TempExtension
+
+mod = import_script("scan_version_compat")
+
+
+REMOVED_API = """\
+#include <Python.h>
+
+static PyObject *
+call_removed(PyObject *self, PyObject *args)
+{
+    return PyObject_CallObject(self, NULL);
+}
+"""
+
+DEPRECATED_API = """\
+#include <Python.h>
+
+static int
+use_deprecated(PyObject *mod)
+{
+    PyModule_AddObject(mod, "x", Py_None);
+    return 0;
+}
+"""
+
+GUARDED_API = """\
+#include <Python.h>
+
+static PyObject *
+use_guarded(PyObject *self, PyObject *args)
+{
+#if PY_VERSION_HEX >= 0x030A0000
+    return Py_NewRef(self);
+#else
+    Py_INCREF(self);
+    return self;
+#endif
+}
+"""
+
+DEAD_GUARD = """\
+#include <Python.h>
+
+#if PY_VERSION_HEX < 0x03090000
+/* Dead code if min python is 3.9 */
+static void old_compat(void) {}
+#endif
+
+static PyObject *
+current_func(PyObject *self, PyObject *args)
+{
+    Py_RETURN_NONE;
+}
+"""
+
+
+class TestScanVersionCompat(unittest.TestCase):
+    """Test version compatibility scanning."""
+
+    def test_detects_removed_api(self):
+        """Detect usage of removed API."""
+        with TempExtension({"ext.c": REMOVED_API}) as root:
+            result = mod.analyze(str(root), min_python="3.15")
+            types = [f["type"] for f in result["findings"]]
+            self.assertIn("removed_api_usage", types)
+
+    def test_detects_deprecated_api(self):
+        """Detect usage of deprecated API."""
+        with TempExtension({"ext.c": DEPRECATED_API}) as root:
+            result = mod.analyze(str(root))
+            types = [f["type"] for f in result["findings"]]
+            self.assertIn("deprecated_api_usage", types)
+
+    def test_guarded_api_no_finding(self):
+        """Version-guarded API usage is not flagged as removed."""
+        with TempExtension({"ext.c": GUARDED_API}) as root:
+            result = mod.analyze(str(root))
+            removed = [f for f in result["findings"]
+                       if f["type"] == "removed_api_usage"]
+            self.assertEqual(len(removed), 0)
+
+    def test_dead_version_guard(self):
+        """Detect dead version guard below minimum Python."""
+        with TempExtension({"ext.c": DEAD_GUARD}) as root:
+            result = mod.analyze(str(root), min_python="3.9")
+            types = [f["type"] for f in result["findings"]]
+            self.assertIn("dead_version_guard", types)
+
+    def test_output_envelope(self):
+        """Output has correct structure."""
+        with TempExtension({"ext.c": REMOVED_API}) as root:
+            result = mod.analyze(str(root))
+            self.assertIn("project_root", result)
+            self.assertIn("findings", result)
+            self.assertIn("summary", result)
+            self.assertIn("min_python", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `deref_macro_on_unchecked` detection to scan_null_checks.py — catches PyBytes_AS_STRING/PyList_GET_ITEM/etc. on unchecked NULL-able values
- Add `dealloc_missing_xdecref` detection to scan_type_slots.py — cross-references struct members against dealloc cleanup
- Handle ALL_CAPS macro wrappers in find_assigned_variable() (scan_common.py)
- New scan_version_compat.py script with 4 finding types: removed_api_usage, deprecated_api_usage, missing_version_guard, dead_version_guard

## Test plan
- [x] All 94 tests pass (84 existing + 10 new)
- [x] New deref_macro_on_unchecked: true positive (PyBytes_AS_STRING on unchecked) and true negative (NULL-checked first)
- [x] New dealloc_missing_xdecref: true positive (3 members, 1 missing) and true negative (all cleaned)
- [x] Macro-wrapped variable names: no garbled output from STATS() wrapper
- [x] scan_version_compat: removed API, deprecated API, guarded API (no finding), dead guard, output envelope

Closes #5

Generated with [Claude Code](https://claude.com/claude-code)