### PR TITLE
feat: C++ support, external tool integration (clang-tidy/cppcheck), agent prompt enhancement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+- C++ file support via optional `tree-sitter-cpp` dependency (.cpp, .cxx, .cc files).
+- `run_external_tools.py` script wrapping clang-tidy and cppcheck with JSON envelope output.
+- Phase 0.5 in `explore.md` for automatic external tool baseline.
+- External Tool Cross-Reference sections in 4 agent prompts (null-safety, error-path, GIL, complexity).
+- `parse_bytes_for_file()` in `tree_sitter_utils.py` — auto-selects C or C++ parser by file extension.
+
+### Changed
+- `discover_c_files()` now finds C++ source files (.cpp, .cxx, .cc) when tree-sitter-cpp is installed.
+- `discover_extension.py` `_find_c_files()` now always finds C++ source files.
+- All 9 scanner scripts now use `parse_bytes_for_file()` for language-aware parsing.
+
 ## [0.1.1] - 2026-03-21
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ Key architectural difference: uses Tree-sitter for C parsing (not regex), enabli
 ## Prerequisites
 - Python 3.10+
 - `tree-sitter` and `tree-sitter-c`: `pip install tree-sitter tree-sitter-c`
+- `tree-sitter-cpp` (optional): `pip install tree-sitter-cpp` — enables C++ file parsing
+- `clang-tidy` and `cppcheck` (optional): system packages — enables external tool cross-referencing
 - No other dependencies — all scripts use only the standard library plus tree-sitter
 
 ## Dev commands
@@ -69,7 +71,7 @@ cext-review-toolkit/
 
 ### Scripts (the core analysis code)
 
-All scripts live in `plugins/cext-review-toolkit/scripts/`. Every analysis script follows the same pattern: parse C files with Tree-sitter, find candidate issues, output JSON to stdout.
+All scripts live in `plugins/cext-review-toolkit/scripts/`. Every analysis script follows the same pattern: parse C/C++ files with Tree-sitter, find candidate issues, output JSON to stdout.
 
 | Script | Lines | Purpose |
 |--------|-------|---------|
@@ -84,8 +86,9 @@ All scripts live in `plugins/cext-review-toolkit/scripts/`. Every analysis scrip
 | `measure_c_complexity.py` | ~250 | Function complexity scoring |
 | `analyze_history.py` | ~520 | Git history analysis (similar bugs, churn prioritization) |
 | `discover_extension.py` | ~420 | Extension project layout detection |
+| `run_external_tools.py` | ~250 | External tool integration (clang-tidy, cppcheck) |
 
-**Dependency graph:** `tree_sitter_utils.py` is at the center. `scan_common.py` imports from it. All other scripts import from both. No circular dependencies.
+**Dependency graph:** `tree_sitter_utils.py` is at the center. `scan_common.py` imports from it. All other scripts import from both. `run_external_tools.py` imports only from `scan_common`. No circular dependencies.
 
 **Script calling convention:** Every analysis script exposes `analyze(target: str, *, max_files: int = 0) -> dict` and a `main()` that outputs JSON to stdout. Exception: `analyze_history.py` takes `argv` to match code-review-toolkit conventions.
 
@@ -163,7 +166,9 @@ Important calibration: module state issues (single-phase init, global state) are
 
 - **Strip comments before pattern matching:** When checking function bodies for patterns like `tp_free` or `Py_VISIT`, always use `strip_comments()` first. Comments containing these strings (e.g., `/* BUG: should use tp_free */`) cause false negatives. This bit us in Round 1 testing.
 - **`sys.path.insert` for imports:** Scripts use `sys.path.insert(0, str(Path(__file__).resolve().parent))` to import `tree_sitter_utils` and `scan_common`. This is intentional — the scripts directory is not a Python package (no `__init__.py`). Tests use `import_script()` which does the same via importlib.
-- **`parse_bytes` vs `parse_file`:** Always use `parse_bytes(source_bytes)` after reading the file yourself, never `parse_file(filepath)` in scanner loops. `parse_file` reads the file again internally, doubling I/O and creating a TOCTOU race.
+- **`parse_bytes_for_file` vs `parse_bytes`:** In scanner loops, always use `parse_bytes_for_file(source_bytes, filepath)` which auto-selects C or C++ parser by extension. `parse_bytes` always uses the C parser. Never use `parse_file(filepath)` — it reads the file again internally, doubling I/O and creating a TOCTOU race.
+- **C++ parsing is optional:** All scripts must work without tree-sitter-cpp. Use `is_cpp_available()` to gate C++ features. Never import `tree_sitter_cpp` directly outside `tree_sitter_utils.py`.
+- **External tools have timeouts:** `run_external_tools.py` uses 120s per-file timeouts for subprocess calls. Large files with complex analysis may time out.
 - **`analyze_history.py` has a different `analyze()` signature:** Takes `argv` list instead of `(target, max_files)` — matches code-review-toolkit's convention but differs from all other scripts.
 
 ## Design document

--- a/plugins/cext-review-toolkit/.claude-plugin/plugin.json
+++ b/plugins/cext-review-toolkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cext-review-toolkit",
   "version": "0.1.1",
-  "description": "CPython C extension analysis agents: refcount auditing (with borrowed-ref-across-callback detection), error path analysis, NULL safety scanning, GIL discipline checking, module state validation, type slot correctness, stable ABI compliance, version compatibility scanning, complexity measurement, and git history analysis. Tree-sitter-powered parsing for accurate analysis of any C extension style.",
+  "description": "CPython C/C++ extension analysis agents: refcount auditing (with borrowed-ref-across-callback detection), error path analysis, NULL safety scanning, GIL discipline checking, module state validation, type slot correctness, stable ABI compliance, version compatibility scanning, complexity measurement, and git history analysis. Tree-sitter-powered C/C++ parsing with optional clang-tidy/cppcheck integration.",
   "author": {
     "name": "Danzin"
   }

--- a/plugins/cext-review-toolkit/agents/c-complexity-analyzer.md
+++ b/plugins/cext-review-toolkit/agents/c-complexity-analyzer.md
@@ -160,6 +160,14 @@ After all findings, include a summary:
 [One paragraph on the codebase's complexity profile: is it generally well-structured with a few hotspots, or is high complexity pervasive?]
 ```
 
+## External Tool Cross-Reference (Optional)
+
+If external tools are available:
+
+1. Run: `python <plugin_root>/scripts/run_external_tools.py [scope]`
+2. Correlate: functions with high complexity AND multiple external tool findings are the strongest refactoring candidates
+3. External tool finding density per function (findings/LOC) is a useful secondary complexity metric
+
 ## Classification Rules
 
 - **FIX**: Not applicable for complexity alone. Complexity is a signal, not a bug. However, if complexity directly prevents correct implementation of a safety fix (e.g., a function is so complex that adding a missing NULL check would require restructuring), note this.

--- a/plugins/cext-review-toolkit/agents/error-path-analyzer.md
+++ b/plugins/cext-review-toolkit/agents/error-path-analyzer.md
@@ -114,6 +114,18 @@ For each confirmed or likely finding, produce a structured entry:
 **Rationale**: [Why this classification was chosen]
 ```
 
+## External Tool Cross-Reference (Optional)
+
+If external tools are available:
+
+1. Run: `python <plugin_root>/scripts/run_external_tools.py [scope] --compile-commands <path>`
+2. Cross-reference findings:
+   - `clang-analyzer-core.uninitialized` confirms unchecked PyArg_Parse output variable usage
+   - `cert-err34-c` confirms missing error checks on conversion functions
+   - `bugprone-branch-clone` may reveal duplicated error handling that has diverged
+   - `clang-analyzer-deadcode.DeadStores` may identify unused error return values
+3. When both our scanner and an external tool flag the same location, upgrade confidence to HIGH
+
 ## Classification Rules
 
 - **FIX**: Missing NULL check before dereference on a reachable code path (will crash). Returning NULL or -1 without an active exception (causes `SystemError`). `PyErr_Clear` that clobbers a real exception that should propagate.

--- a/plugins/cext-review-toolkit/agents/gil-discipline-checker.md
+++ b/plugins/cext-review-toolkit/agents/gil-discipline-checker.md
@@ -132,6 +132,17 @@ For each confirmed or likely finding, produce a structured entry:
 **Rationale**: [Why this classification was chosen]
 ```
 
+## External Tool Cross-Reference (Optional)
+
+If external tools are available:
+
+1. Run: `python <plugin_root>/scripts/run_external_tools.py [scope] --compile-commands <path>`
+2. Cross-reference findings:
+   - Thread safety annotations from clang-tidy provide GIL-independent thread safety guarantees
+   - `bugprone-use-after-move` may indicate unsafe state after GIL release/reacquire
+   - `clang-analyzer-core.StackAddressEscape` may indicate variables used across GIL boundaries
+3. External tool findings are particularly valuable for C++ extensions where our tree-sitter C parser has limited coverage
+
 ## Classification Rules
 
 - **FIX**: Python API call without the GIL held (crash or corruption). Mismatched `Py_BEGIN_ALLOW_THREADS` / `Py_END_ALLOW_THREADS` (GIL permanently released). Mismatched `PyGILState_Ensure` / `PyGILState_Release` (GIL leak or double-release). Foreign library callback that touches Python objects without GIL.

--- a/plugins/cext-review-toolkit/agents/null-safety-scanner.md
+++ b/plugins/cext-review-toolkit/agents/null-safety-scanner.md
@@ -112,6 +112,19 @@ For each confirmed or likely finding, produce a structured entry:
 **Rationale**: [Why this classification was chosen]
 ```
 
+## External Tool Cross-Reference (Optional)
+
+If external tools are available, enhance your analysis:
+
+1. Check for `compile_commands.json` in the project root or build directory
+2. If found, run: `python <plugin_root>/scripts/run_external_tools.py [scope] --compile-commands <path>`
+3. Cross-reference findings:
+   - `clang-analyzer-core.NullDereference` confirms `unchecked_alloc` and `deref_before_check` candidates with data-flow precision
+   - `cppcheck nullPointer` may catch inter-procedural NULL propagation our pattern-based scanner misses
+   - When both our scanner and an external tool flag the same location, upgrade confidence to HIGH
+   - External-tool-only findings should be included but noted as "Source: clang-tidy" or "Source: cppcheck"
+4. External tool findings use the same FIX/CONSIDER/ACCEPTABLE classification
+
 ## Classification Rules
 
 - **FIX**: NULL dereference on a reachable code path. This includes:

--- a/plugins/cext-review-toolkit/commands/explore.md
+++ b/plugins/cext-review-toolkit/commands/explore.md
@@ -30,6 +30,7 @@ Parse arguments into three categories:
 - `compat` → version-compat-scanner
 - `complexity` → c-complexity-analyzer
 - `history` → git-history-analyzer
+- `external-tools` → run external tools only (clang-tidy, cppcheck)
 - `all` → all agents (default)
 
 **Options**:
@@ -56,6 +57,25 @@ Limited API: no
 ```
 
 If no C extension source files are found, inform the user and suggest checking the scope.
+
+### Phase 0.5: External Tool Baseline (Optional)
+
+After extension discovery, check for external tool availability:
+1. Check if `compile_commands.json` exists in the project root or common build directories (build/, _build/, builddir/)
+2. If found: run `python <plugin_root>/scripts/run_external_tools.py [scope] --compile-commands <path>`
+3. If not found: run `python <plugin_root>/scripts/run_external_tools.py [scope]` (cppcheck can still run without it)
+4. Store the output -- individual agents in Phase 2 will cross-reference these findings
+5. Print a brief tool summary:
+
+```
+External tools: clang-tidy (with compile_commands.json), cppcheck
+External findings: 3 clang-tidy, 5 cppcheck
+```
+
+If no external tools are available, note it and continue without:
+```
+External tools: none available (install clang-tidy and/or cppcheck for enhanced analysis)
+```
 
 ### Phase 1: Temporal Context (if git repo)
 

--- a/plugins/cext-review-toolkit/scripts/analyze_history.py
+++ b/plugins/cext-review-toolkit/scripts/analyze_history.py
@@ -26,7 +26,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from tree_sitter_utils import parse_bytes, extract_functions
+from tree_sitter_utils import parse_bytes_for_file, extract_functions
 from scan_common import find_project_root
 
 CLASSIFICATION_RULES: list[tuple[str, list[str]]] = [
@@ -192,7 +192,7 @@ def _get_c_function_boundaries(filepath: Path) -> list[dict]:
     """Use Tree-sitter to get C function boundaries."""
     try:
         source_bytes = filepath.read_bytes()
-        tree = parse_bytes(source_bytes)
+        tree = parse_bytes_for_file(source_bytes, filepath)
         functions = extract_functions(tree, source_bytes)
         return [
             {"name": f["name"], "line_start": f["start_line"],

--- a/plugins/cext-review-toolkit/scripts/discover_extension.py
+++ b/plugins/cext-review-toolkit/scripts/discover_extension.py
@@ -30,18 +30,22 @@ def _should_skip(path: Path, root: Path) -> bool:
     return bool(parts & EXCLUDE_DIRS)
 
 
+_SOURCE_GLOBS = ("*.c", "*.cpp", "*.cxx", "*.cc")
+
+
 def _find_c_files(root: Path) -> list[Path]:
-    """Find all .c files under root, excluding common build dirs."""
+    """Find all C/C++ source files under root, excluding common build dirs."""
     result = []
     if not root.is_dir():
         return result
-    for p in sorted(root.rglob("*.c")):
-        if not p.is_file():
-            continue
-        if _should_skip(p, root):
-            continue
-        result.append(p)
-    return result
+    for pattern in _SOURCE_GLOBS:
+        for p in sorted(root.rglob(pattern)):
+            if not p.is_file():
+                continue
+            if _should_skip(p, root):
+                continue
+            result.append(p)
+    return sorted(set(result))
 
 
 def _find_h_files(root: Path, c_files: list[Path]) -> list[Path]:

--- a/plugins/cext-review-toolkit/scripts/measure_c_complexity.py
+++ b/plugins/cext-review-toolkit/scripts/measure_c_complexity.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 # Import shared utilities.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from tree_sitter_utils import parse_bytes, extract_functions, get_node_text, walk_descendants, strip_comments
+from tree_sitter_utils import parse_bytes_for_file, extract_functions, get_node_text, walk_descendants, strip_comments
 from scan_common import find_project_root, discover_c_files, parse_common_args
 
 
@@ -159,7 +159,7 @@ def analyze(target: str, *, max_files: int = 0) -> dict:
             skipped.append({"file": str(filepath), "reason": str(e)})
             continue
 
-        tree = parse_bytes(source_bytes)
+        tree = parse_bytes_for_file(source_bytes, filepath)
         functions = extract_functions(tree, source_bytes)
         if not functions:
             continue

--- a/plugins/cext-review-toolkit/scripts/run_external_tools.py
+++ b/plugins/cext-review-toolkit/scripts/run_external_tools.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Run external static analysis tools (clang-tidy, cppcheck) on C/C++ code.
+
+Outputs JSON matching the standard cext-review-toolkit envelope format.
+Both tools are optional -- gracefully skips unavailable ones.
+
+Usage:
+    python run_external_tools.py [path] [--max-files N] [--compile-commands PATH]
+    python run_external_tools.py [path] [--skip TOOL[,TOOL]]
+    python run_external_tools.py [path] [--tools TOOL[,TOOL]]
+"""
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from scan_common import find_project_root, discover_c_files
+
+
+_PER_FILE_TIMEOUT = 120
+
+
+def _tool_available(name: str) -> bool:
+    """Check if an external tool is on PATH."""
+    return shutil.which(name) is not None
+
+
+def _find_compile_commands(root: Path, explicit: str | None) -> Path | None:
+    """Find compile_commands.json in common locations."""
+    if explicit:
+        p = Path(explicit)
+        if p.is_file():
+            return p
+        if p.is_dir():
+            cc = p / "compile_commands.json"
+            if cc.is_file():
+                return cc
+        return None
+    for candidate in [
+        root / "compile_commands.json",
+        root / "build" / "compile_commands.json",
+        root / "_build" / "compile_commands.json",
+        root / "builddir" / "compile_commands.json",
+    ]:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _run_clang_tidy(
+    files: list[Path], compile_commands: Path, project_root: Path,
+) -> list[dict]:
+    """Run clang-tidy on files using the compile database."""
+    findings = []
+    checks = "-*,clang-analyzer-*,bugprone-*,cert-*"
+
+    for filepath in files:
+        try:
+            result = subprocess.run(
+                [
+                    "clang-tidy",
+                    f"-p={compile_commands.parent}",
+                    f"--checks={checks}",
+                    "--quiet",
+                    str(filepath),
+                ],
+                capture_output=True, text=True,
+                timeout=_PER_FILE_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired:
+            continue
+        except FileNotFoundError:
+            break
+
+        for line in result.stdout.splitlines():
+            m = re.match(
+                r"^(.+?):(\d+):\d+:\s+(warning|error|note):\s+(.+?)\s+\[(.+)\]$",
+                line,
+            )
+            if not m:
+                continue
+            fpath, lineno, severity, message, checker = m.groups()
+            try:
+                rel = str(Path(fpath).relative_to(project_root))
+            except ValueError:
+                rel = fpath
+            findings.append({
+                "type": "clang_tidy_finding",
+                "file": rel,
+                "line": int(lineno),
+                "checker": checker,
+                "severity": severity,
+                "detail": message,
+                "confidence": "high",
+                "tool": "clang-tidy",
+            })
+
+    return findings
+
+
+def _run_cppcheck(
+    files: list[Path], project_root: Path,
+    compile_commands: Path | None = None,
+) -> list[dict]:
+    """Run cppcheck on files (works without compile_commands.json)."""
+    findings = []
+    if not files:
+        return findings
+
+    cmd = [
+        "cppcheck",
+        "--enable=warning,performance,portability",
+        "--xml",
+        "--quiet",
+    ]
+    if compile_commands:
+        cmd.append(f"--project={compile_commands}")
+    else:
+        cmd.extend(str(f) for f in files)
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True, text=True,
+            timeout=_PER_FILE_TIMEOUT * len(files),
+        )
+    except subprocess.TimeoutExpired:
+        return findings
+    except FileNotFoundError:
+        return findings
+
+    # Parse XML output from stderr (cppcheck sends XML to stderr).
+    xml_output = result.stderr
+    if not xml_output.strip().startswith("<?xml"):
+        return findings
+
+    try:
+        root_elem = ET.fromstring(xml_output)
+    except ET.ParseError:
+        return findings
+
+    errors = root_elem.find("errors")
+    if errors is None:
+        return findings
+
+    for error in errors.findall("error"):
+        checker = error.get("id", "unknown")
+        severity = error.get("severity", "warning")
+        message = error.get("msg", "")
+
+        # Skip informational messages.
+        if severity == "information":
+            continue
+
+        location = error.find("location")
+        if location is None:
+            continue
+        fpath = location.get("file", "")
+        lineno = int(location.get("line", "0"))
+
+        try:
+            rel = str(Path(fpath).relative_to(project_root))
+        except ValueError:
+            rel = fpath
+
+        findings.append({
+            "type": "cppcheck_finding",
+            "file": rel,
+            "line": lineno,
+            "checker": checker,
+            "severity": severity,
+            "detail": message,
+            "confidence": "high" if severity == "error" else "medium",
+            "tool": "cppcheck",
+        })
+
+    return findings
+
+
+def analyze(
+    target: str, *, max_files: int = 0,
+    compile_commands: str | None = None,
+    skip_tools: set[str] | None = None,
+    only_tools: set[str] | None = None,
+) -> dict:
+    """Run external tools and return findings in standard envelope."""
+    target_path = Path(target).resolve()
+    project_root = find_project_root(target_path)
+    scan_root = target_path if target_path.is_dir() else target_path.parent
+
+    cc_path = _find_compile_commands(project_root, compile_commands)
+
+    has_tidy = _tool_available("clang-tidy")
+    has_cppcheck = _tool_available("cppcheck")
+
+    skip = skip_tools or set()
+    if only_tools:
+        if "clang-tidy" not in only_tools:
+            skip.add("clang-tidy")
+        if "cppcheck" not in only_tools:
+            skip.add("cppcheck")
+
+    files = list(discover_c_files(scan_root, max_files=max_files))
+
+    findings = []
+    skipped_tools = []
+
+    # clang-tidy
+    if "clang-tidy" in skip:
+        skipped_tools.append({"tool": "clang-tidy", "reason": "skipped by user"})
+    elif not has_tidy:
+        skipped_tools.append({"tool": "clang-tidy", "reason": "not installed"})
+    elif not cc_path:
+        skipped_tools.append({
+            "tool": "clang-tidy",
+            "reason": "no compile_commands.json found",
+        })
+    else:
+        findings.extend(_run_clang_tidy(files, cc_path, project_root))
+
+    # cppcheck
+    if "cppcheck" in skip:
+        skipped_tools.append({"tool": "cppcheck", "reason": "skipped by user"})
+    elif not has_cppcheck:
+        skipped_tools.append({"tool": "cppcheck", "reason": "not installed"})
+    else:
+        findings.extend(_run_cppcheck(files, project_root, cc_path))
+
+    by_tool = defaultdict(int)
+    by_severity = defaultdict(int)
+    for f in findings:
+        by_tool[f["tool"]] += 1
+        by_severity[f["severity"]] += 1
+
+    return {
+        "project_root": str(project_root),
+        "scan_root": str(scan_root),
+        "files_analyzed": len(files),
+        "tools_available": {
+            "clang_tidy": has_tidy,
+            "cppcheck": has_cppcheck,
+        },
+        "compile_commands": str(cc_path) if cc_path else None,
+        "findings": findings,
+        "summary": {
+            "total_findings": len(findings),
+            "by_tool": dict(by_tool),
+            "by_severity": dict(by_severity),
+        },
+        "skipped_tools": skipped_tools,
+    }
+
+
+def main() -> None:
+    try:
+        max_files = 0
+        compile_commands = None
+        skip_tools: set[str] = set()
+        only_tools: set[str] | None = None
+        positional: list[str] = []
+        argv = sys.argv[1:]
+        i = 0
+        while i < len(argv):
+            if argv[i] == "--max-files" and i + 1 < len(argv):
+                max_files = int(argv[i + 1])
+                i += 2
+            elif argv[i] == "--compile-commands" and i + 1 < len(argv):
+                compile_commands = argv[i + 1]
+                i += 2
+            elif argv[i] == "--skip" and i + 1 < len(argv):
+                skip_tools = set(argv[i + 1].split(","))
+                i += 2
+            elif argv[i] == "--tools" and i + 1 < len(argv):
+                only_tools = set(argv[i + 1].split(","))
+                i += 2
+            elif argv[i].startswith("--"):
+                i += 1
+            else:
+                positional.append(argv[i])
+                i += 1
+        target = positional[0] if positional else "."
+        result = analyze(
+            target, max_files=max_files,
+            compile_commands=compile_commands,
+            skip_tools=skip_tools if skip_tools else None,
+            only_tools=only_tools,
+        )
+        json.dump(result, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    except Exception as e:
+        json.dump({"error": str(e), "type": type(e).__name__},
+                  sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/cext-review-toolkit/scripts/scan_common.py
+++ b/plugins/cext-review-toolkit/scripts/scan_common.py
@@ -21,7 +21,10 @@ except ImportError:
     sys.exit(1)
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from tree_sitter_utils import get_node_text, get_declarator_name
+from tree_sitter_utils import (
+    get_node_text, get_declarator_name,
+    C_EXTENSIONS, ALL_SOURCE_EXTENSIONS, is_cpp_available,
+)
 
 
 EXCLUDE_DIRS = frozenset({
@@ -52,17 +55,23 @@ def find_project_root(start: Path) -> Path:
     return start if start.is_dir() else start.parent
 
 
+def _get_source_extensions() -> frozenset[str]:
+    """Return file extensions to scan (C only, or C+C++ if available)."""
+    return ALL_SOURCE_EXTENSIONS if is_cpp_available() else C_EXTENSIONS
+
+
 def discover_c_files(
     root: Path, *, max_files: int = 0,
 ) -> Generator[Path, None, None]:
-    """Discover C source files under root, excluding common build dirs."""
+    """Discover C/C++ source files under root, excluding common build dirs."""
+    exts = _get_source_extensions()
     count = 0
     if root.is_file():
-        if root.suffix in (".c", ".h"):
+        if root.suffix in exts:
             yield root
         return
     for p in sorted(root.rglob("*")):
-        if not p.is_file() or p.suffix not in (".c", ".h"):
+        if not p.is_file() or p.suffix not in exts:
             continue
         try:
             parts = set(p.relative_to(root).parts)

--- a/plugins/cext-review-toolkit/scripts/scan_error_paths.py
+++ b/plugins/cext-review-toolkit/scripts/scan_error_paths.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from tree_sitter_utils import (
-    parse_bytes, extract_functions, find_calls_in_scope,
+    parse_bytes_for_file, extract_functions, find_calls_in_scope,
     find_return_statements, get_node_text, walk_descendants,
     get_declarator_name,
 )
@@ -277,7 +277,7 @@ def analyze(target: str, *, max_files: int = 0) -> dict:
             skipped.append({"file": str(filepath), "reason": str(e)})
             continue
 
-        tree = parse_bytes(source_bytes)
+        tree = parse_bytes_for_file(source_bytes, filepath)
         functions = extract_functions(tree, source_bytes)
         if not functions:
             continue

--- a/plugins/cext-review-toolkit/scripts/scan_gil_usage.py
+++ b/plugins/cext-review-toolkit/scripts/scan_gil_usage.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from tree_sitter_utils import (
-    parse_bytes, extract_functions, find_calls_in_scope,
+    parse_bytes_for_file, extract_functions, find_calls_in_scope,
     extract_static_declarations,
     get_node_text, walk_descendants, strip_comments,
 )
@@ -266,7 +266,7 @@ def analyze(target: str, *, max_files: int = 0) -> dict:
             skipped.append({"file": str(filepath), "reason": str(e)})
             continue
 
-        tree = parse_bytes(source_bytes)
+        tree = parse_bytes_for_file(source_bytes, filepath)
         functions = extract_functions(tree, source_bytes)
         if not functions:
             continue

--- a/plugins/cext-review-toolkit/scripts/scan_module_state.py
+++ b/plugins/cext-review-toolkit/scripts/scan_module_state.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from tree_sitter_utils import (
-    parse_bytes, extract_functions, find_calls_in_scope,
+    parse_bytes_for_file, extract_functions, find_calls_in_scope,
     extract_struct_initializers, extract_static_declarations,
     get_node_text, walk_descendants,
 )
@@ -245,7 +245,7 @@ def analyze(target: str, *, max_files: int = 0) -> dict:
             skipped.append({"file": str(filepath), "reason": str(e)})
             continue
 
-        tree = parse_bytes(source_bytes)
+        tree = parse_bytes_for_file(source_bytes, filepath)
         functions = extract_functions(tree, source_bytes)
         if not functions:
             continue

--- a/plugins/cext-review-toolkit/scripts/scan_null_checks.py
+++ b/plugins/cext-review-toolkit/scripts/scan_null_checks.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from tree_sitter_utils import (
-    parse_bytes, extract_functions, find_calls_in_scope,
+    parse_bytes_for_file, extract_functions, find_calls_in_scope,
     get_node_text, walk_descendants, get_declarator_name,
 )
 from scan_common import (
@@ -270,7 +270,7 @@ def analyze(target: str, *, max_files: int = 0) -> dict:
             skipped.append({"file": str(filepath), "reason": str(e)})
             continue
 
-        tree = parse_bytes(source_bytes)
+        tree = parse_bytes_for_file(source_bytes, filepath)
         functions = extract_functions(tree, source_bytes)
         if not functions:
             continue

--- a/plugins/cext-review-toolkit/scripts/scan_refcounts.py
+++ b/plugins/cext-review-toolkit/scripts/scan_refcounts.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from tree_sitter_utils import (
-    parse_bytes, extract_functions, find_calls_in_scope,
+    parse_bytes_for_file, extract_functions, find_calls_in_scope,
     find_assignments_in_scope, find_return_statements,
     get_node_text, walk_descendants, get_declarator_name,
 )
@@ -317,7 +317,7 @@ def analyze(target: str, *, max_files: int = 0) -> dict:
             skipped.append({"file": str(filepath), "reason": str(e)})
             continue
 
-        tree = parse_bytes(source_bytes)
+        tree = parse_bytes_for_file(source_bytes, filepath)
         functions = extract_functions(tree, source_bytes)
         if not functions:
             continue

--- a/plugins/cext-review-toolkit/scripts/scan_type_slots.py
+++ b/plugins/cext-review-toolkit/scripts/scan_type_slots.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from tree_sitter_utils import (
-    parse_bytes, extract_functions, find_calls_in_scope,
+    parse_bytes_for_file, extract_functions, find_calls_in_scope,
     extract_struct_initializers, find_struct_members,
     get_node_text, walk_descendants, strip_comments,
 )
@@ -399,7 +399,7 @@ def analyze(target: str, *, max_files: int = 0) -> dict:
             skipped.append({"file": str(filepath), "reason": str(e)})
             continue
 
-        tree = parse_bytes(source_bytes)
+        tree = parse_bytes_for_file(source_bytes, filepath)
         functions = extract_functions(tree, source_bytes)
         if not functions:
             continue

--- a/plugins/cext-review-toolkit/scripts/scan_version_compat.py
+++ b/plugins/cext-review-toolkit/scripts/scan_version_compat.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from tree_sitter_utils import (
-    parse_bytes, extract_functions, find_calls_in_scope,
+    parse_bytes_for_file, extract_functions, find_calls_in_scope,
     get_node_text, strip_comments,
 )
 from scan_common import find_project_root, discover_c_files
@@ -245,7 +245,7 @@ def analyze(target: str, *, max_files: int = 0,
             skipped.append({"file": str(filepath), "reason": str(e)})
             continue
 
-        tree = parse_bytes(source_bytes)
+        tree = parse_bytes_for_file(source_bytes, filepath)
         functions = extract_functions(tree, source_bytes)
         source_text = source_bytes.decode("utf-8", errors="replace")
 

--- a/plugins/cext-review-toolkit/scripts/tree_sitter_utils.py
+++ b/plugins/cext-review-toolkit/scripts/tree_sitter_utils.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""Tree-sitter parsing utilities for C extension analysis.
+"""Tree-sitter parsing utilities for C/C++ extension analysis.
 
 This is the core parsing module used by all analysis scripts in
-cext-review-toolkit. It provides structured access to C source code
+cext-review-toolkit. It provides structured access to C/C++ source code
 via Tree-sitter, replacing fragile regex-based parsing.
 
 Requires: pip install tree-sitter tree-sitter-c
+Optional: pip install tree-sitter-cpp (for C++ file support)
 """
 
 import json
@@ -26,6 +27,49 @@ except ImportError:
 # Initialize the C parser once at module level.
 C_LANGUAGE = tree_sitter.Language(tree_sitter_c.language())
 _parser = tree_sitter.Parser(C_LANGUAGE)
+
+# C++ support (optional).
+_CPP_AVAILABLE = False
+_cpp_parser: tree_sitter.Parser | None = None
+
+try:
+    import tree_sitter_cpp
+    _CPP_AVAILABLE = True
+except ImportError:
+    pass
+
+C_EXTENSIONS = frozenset({".c", ".h"})
+CPP_EXTENSIONS = frozenset({".cpp", ".cxx", ".cc", ".hpp"})
+ALL_SOURCE_EXTENSIONS = C_EXTENSIONS | CPP_EXTENSIONS
+
+
+def is_cpp_available() -> bool:
+    """Check if tree-sitter-cpp is installed."""
+    return _CPP_AVAILABLE
+
+
+def _get_cpp_parser() -> tree_sitter.Parser:
+    """Lazily initialize and return the C++ parser."""
+    global _cpp_parser
+    if _cpp_parser is None:
+        if not _CPP_AVAILABLE:
+            raise ImportError("tree-sitter-cpp not installed: pip install tree-sitter-cpp")
+        cpp_language = tree_sitter.Language(tree_sitter_cpp.language())
+        _cpp_parser = tree_sitter.Parser(cpp_language)
+    return _cpp_parser
+
+
+def get_parser_for_file(filepath: Path) -> tree_sitter.Parser:
+    """Return the appropriate parser for a file based on its extension."""
+    if filepath.suffix in CPP_EXTENSIONS and _CPP_AVAILABLE:
+        return _get_cpp_parser()
+    return _parser
+
+
+def parse_bytes_for_file(source_bytes: bytes, filepath: Path) -> tree_sitter.Tree:
+    """Parse source bytes using the parser appropriate for the file type."""
+    parser = get_parser_for_file(filepath)
+    return parser.parse(source_bytes)
 
 
 def parse_file(path: Path) -> tree_sitter.Tree:
@@ -130,7 +174,20 @@ def extract_functions(tree: tree_sitter.Tree, source_bytes: bytes) -> list[dict]
     functions = []
     root = tree.root_node
 
+    # Collect top-level nodes, descending into extern "C" {} and namespace {}
+    # blocks which wrap function definitions in C++ files.
+    top_nodes = []
     for node in root.children:
+        if node.type in ("linkage_specification", "namespace_definition"):
+            body = node.child_by_field_name("body")
+            if body:
+                top_nodes.extend(body.children)
+            else:
+                top_nodes.extend(node.children)
+        else:
+            top_nodes.append(node)
+
+    for node in top_nodes:
         if node.type != "function_definition":
             continue
 

--- a/tests/test_cpp_support.py
+++ b/tests/test_cpp_support.py
@@ -1,0 +1,117 @@
+"""Tests for C++ file support in tree_sitter_utils and scan_common."""
+
+import unittest
+from pathlib import Path
+from helpers import import_script, TempExtension
+
+ts = import_script("tree_sitter_utils")
+scan_common = import_script("scan_common")
+
+CPP_EXTENSION = """\
+#include <Python.h>
+
+extern "C" {
+
+static PyObject *
+myext_hello(PyObject *self, PyObject *args)
+{
+    return PyUnicode_FromString("hello from C++");
+}
+
+static PyMethodDef methods[] = {
+    {"hello", myext_hello, METH_NOARGS, NULL},
+    {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef module = {
+    PyModuleDef_HEAD_INIT,
+    "myext",
+    NULL,
+    -1,
+    methods
+};
+
+PyMODINIT_FUNC
+PyInit_myext(void)
+{
+    return PyModule_Create(&module);
+}
+
+}
+"""
+
+
+class TestCppSupport(unittest.TestCase):
+    """Test C++ file parsing support."""
+
+    def test_cpp_available_flag(self):
+        """is_cpp_available returns bool."""
+        result = ts.is_cpp_available()
+        self.assertIsInstance(result, bool)
+
+    def test_c_file_uses_c_parser(self):
+        """C file still uses C parser."""
+        parser = ts.get_parser_for_file(Path("test.c"))
+        self.assertIs(parser, ts._parser)
+
+    def test_h_file_uses_c_parser(self):
+        """Header file uses C parser."""
+        parser = ts.get_parser_for_file(Path("test.h"))
+        self.assertIs(parser, ts._parser)
+
+    def test_extension_constants(self):
+        """Extension constants are defined correctly."""
+        self.assertIn(".c", ts.C_EXTENSIONS)
+        self.assertIn(".h", ts.C_EXTENSIONS)
+        self.assertIn(".cpp", ts.CPP_EXTENSIONS)
+        self.assertIn(".cc", ts.CPP_EXTENSIONS)
+        self.assertIn(".cxx", ts.CPP_EXTENSIONS)
+        self.assertTrue(ts.C_EXTENSIONS < ts.ALL_SOURCE_EXTENSIONS)
+
+    @unittest.skipUnless(ts.is_cpp_available(), "tree-sitter-cpp not installed")
+    def test_cpp_file_uses_cpp_parser(self):
+        """C++ file uses C++ parser when available."""
+        parser = ts.get_parser_for_file(Path("test.cpp"))
+        self.assertIsNot(parser, ts._parser)
+
+    @unittest.skipUnless(ts.is_cpp_available(), "tree-sitter-cpp not installed")
+    def test_parse_cpp_file(self):
+        """C++ file parsed without errors."""
+        tree = ts.parse_bytes_for_file(
+            CPP_EXTENSION.encode(), Path("test.cpp"))
+        self.assertIsNotNone(tree)
+
+    @unittest.skipUnless(ts.is_cpp_available(), "tree-sitter-cpp not installed")
+    def test_extract_functions_from_cpp(self):
+        """Functions extracted from C++ source."""
+        source = CPP_EXTENSION.encode()
+        tree = ts.parse_bytes_for_file(source, Path("test.cpp"))
+        funcs = ts.extract_functions(tree, source)
+        names = [f["name"] for f in funcs]
+        self.assertIn("myext_hello", names)
+        self.assertIn("PyInit_myext", names)
+
+    @unittest.skipUnless(ts.is_cpp_available(), "tree-sitter-cpp not installed")
+    def test_discover_c_files_includes_cpp(self):
+        """discover_c_files finds .cpp files when cpp is available."""
+        with TempExtension({
+            "a.c": "#include <Python.h>\n",
+            "b.cpp": "#include <Python.h>\n",
+            "c.cxx": "#include <Python.h>\n",
+        }) as root:
+            files = list(scan_common.discover_c_files(root))
+            suffixes = {f.suffix for f in files}
+            self.assertIn(".c", suffixes)
+            self.assertIn(".cpp", suffixes)
+            self.assertIn(".cxx", suffixes)
+
+    def test_parse_bytes_for_file_c_fallback(self):
+        """parse_bytes_for_file works for C files regardless of cpp support."""
+        code = b"int main(void) { return 0; }"
+        tree = ts.parse_bytes_for_file(code, Path("test.c"))
+        self.assertIsNotNone(tree)
+        self.assertEqual(tree.root_node.type, "translation_unit")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run_external_tools.py
+++ b/tests/test_run_external_tools.py
@@ -1,0 +1,83 @@
+"""Tests for run_external_tools.py — external static analysis tool integration."""
+
+import shutil
+import unittest
+from helpers import import_script, TempExtension, MINIMAL_EXTENSION, EXTENSION_WITH_BUGS
+
+ext_tools = import_script("run_external_tools")
+
+
+class TestRunExternalTools(unittest.TestCase):
+    """Test external tool wrapper script."""
+
+    def test_analyze_returns_envelope(self):
+        """analyze() returns standard envelope structure."""
+        with TempExtension({"myext.c": MINIMAL_EXTENSION}) as root:
+            result = ext_tools.analyze(str(root))
+            self.assertIn("findings", result)
+            self.assertIn("summary", result)
+            self.assertIn("tools_available", result)
+            self.assertIn("skipped_tools", result)
+            self.assertIn("files_analyzed", result)
+            self.assertIn("compile_commands", result)
+
+    def test_tool_availability_detection(self):
+        """Tool availability correctly detected."""
+        self.assertIsInstance(ext_tools._tool_available("clang-tidy"), bool)
+        self.assertIsInstance(ext_tools._tool_available("cppcheck"), bool)
+        self.assertFalse(ext_tools._tool_available("nonexistent_tool_xyz"))
+
+    def test_missing_tool_graceful(self):
+        """Missing tool produces skip note, not error."""
+        with TempExtension({"myext.c": MINIMAL_EXTENSION}) as root:
+            result = ext_tools.analyze(
+                str(root), skip_tools={"clang-tidy", "cppcheck"})
+            self.assertIsInstance(result["findings"], list)
+            self.assertEqual(len(result["findings"]), 0)
+            self.assertEqual(len(result["skipped_tools"]), 2)
+
+    def test_compile_commands_search(self):
+        """compile_commands.json found in project root."""
+        cc_json = '[{"directory":".","file":"myext.c","command":"cc -c myext.c"}]'
+        with TempExtension({
+            "myext.c": MINIMAL_EXTENSION,
+            "compile_commands.json": cc_json,
+        }) as root:
+            cc = ext_tools._find_compile_commands(root, None)
+            self.assertIsNotNone(cc)
+
+    def test_compile_commands_not_found(self):
+        """No compile_commands.json returns None."""
+        with TempExtension({"myext.c": MINIMAL_EXTENSION}) as root:
+            cc = ext_tools._find_compile_commands(root, None)
+            self.assertIsNone(cc)
+
+    def test_skip_tools_flag(self):
+        """--skip flag prevents tool execution."""
+        with TempExtension({"myext.c": MINIMAL_EXTENSION}) as root:
+            result = ext_tools.analyze(
+                str(root), skip_tools={"clang-tidy", "cppcheck"})
+            skipped_names = [s["tool"] for s in result["skipped_tools"]]
+            self.assertIn("clang-tidy", skipped_names)
+            self.assertIn("cppcheck", skipped_names)
+
+    @unittest.skipUnless(shutil.which("cppcheck"), "cppcheck not installed")
+    def test_cppcheck_runs_on_c_file(self):
+        """cppcheck runs and produces output on C file."""
+        with TempExtension({"myext.c": MINIMAL_EXTENSION}) as root:
+            result = ext_tools.analyze(
+                str(root), skip_tools={"clang-tidy"})
+            self.assertTrue(result["tools_available"]["cppcheck"])
+
+    def test_output_summary_structure(self):
+        """Summary has expected sub-fields."""
+        with TempExtension({"myext.c": MINIMAL_EXTENSION}) as root:
+            result = ext_tools.analyze(str(root))
+            summary = result["summary"]
+            self.assertIn("total_findings", summary)
+            self.assertIn("by_tool", summary)
+            self.assertIn("by_severity", summary)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add optional tree-sitter-cpp for C++ file parsing — memray analysis went from 282 functions (C-only) to 1,231 functions across 22 files
- New `run_external_tools.py` wrapping clang-tidy and cppcheck with JSON envelope output, compile_commands.json discovery, graceful degradation
- External Tool Cross-Reference sections added to 4 agent prompts + Phase 0.5 in explore command

## Test plan
- [x] All 111 tests pass (94 existing + 9 C++ support + 8 external tools)
- [x] C++ functions extracted correctly from extern "C" {} and namespace {} blocks
- [x] discover_c_files() finds .cpp/.cxx/.cc files when tree-sitter-cpp installed
- [x] run_external_tools.py gracefully handles missing tools
- [x] End-to-end: scan_refcounts.py finds 203 findings in memray's C++ code (was 0)
- [x] Existing C-only functionality unaffected (all Round 1-2 tests still pass)

Closes #7

Generated with [Claude Code](https://claude.com/claude-code)