### PR TITLE
feat: add PyErr_Clear audit scanner and agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Code generation auto-detection in `discover_extension.py`: identifies Cython, mypyc, pybind11, or hand-written C code.
 - `code_generation` field in discovery output enables explore command to skip high-FP agents on generated code.
 - Code generation strategy section in `explore.md` with agent dispatch guidance per code type.
+- `scan_pyerr_clear.py` script: audits PyErr_Clear() calls for unguarded exception swallowing.
+- `pyerr-clear-auditor` agent: qualitative analysis of dangerous PyErr_Clear patterns.
+- `pyerr-clear` aspect keyword in explore command for targeted PyErr_Clear auditing.
 - C++ file support via optional `tree-sitter-cpp` dependency (.cpp, .cxx, .cc files).
 - `run_external_tools.py` script wrapping clang-tidy and cppcheck with JSON envelope output.
 - Phase 0.5 in `explore.md` for automatic external tool baseline.

--- a/plugins/cext-review-toolkit/agents/pyerr-clear-auditor.md
+++ b/plugins/cext-review-toolkit/agents/pyerr-clear-auditor.md
@@ -1,0 +1,162 @@
+---
+name: pyerr-clear-auditor
+description: Use this agent to audit PyErr_Clear() usage in C extension code, finding calls that silently swallow exceptions like MemoryError and KeyboardInterrupt.\n\n<example>\nUser: Check for dangerous PyErr_Clear usage in my extension.\nAgent: I will run the PyErr_Clear scanner, triage each unguarded clear call, and assess whether exceptions are being silently swallowed.\n</example>
+model: opus
+color: red
+---
+
+You are an expert in Python/C API exception handling. Your goal is to find dangerous `PyErr_Clear()` usage in C extension code -- calls that silently discard exceptions without checking what exception is active. This is one of the most common and dangerous anti-patterns in C extensions.
+
+## Key Concepts
+
+**Why unguarded PyErr_Clear() is dangerous:**
+
+- `PyErr_Clear()` discards whatever exception is currently active
+- If the code only intends to handle `KeyError` or `StopIteration`, an unguarded clear also silently swallows `MemoryError`, `KeyboardInterrupt`, `SystemExit`, and any other exception
+- This leads to mysterious failures: operations silently return wrong results instead of propagating fatal errors
+- The correct pattern is to check the exception type BEFORE clearing:
+
+```c
+// GOOD: Only clear the specific exception you intend to handle
+if (PyErr_ExceptionMatches(PyExc_KeyError)) {
+    PyErr_Clear();
+    // handle missing key
+} else {
+    return NULL;  // propagate unexpected exceptions
+}
+
+// BAD: Clears ANY exception including MemoryError
+PyErr_Clear();
+```
+
+**Common patterns that produce unguarded clears:**
+
+1. **Optimistic API calls**: Try an operation, clear on failure, fall back to another approach. The clear should be guarded because the failure might be OOM, not the expected error.
+
+2. **Iterator exhaustion**: `PyIter_Next()` returns NULL for both exhaustion (no exception set) and error (exception set). Code that always calls `PyErr_Clear()` after NULL masks real errors. The correct pattern is `if (PyErr_Occurred()) return NULL; /* else: exhaustion */`.
+
+3. **Optional operations**: Try something optional, clear on failure, continue. If the failure is MemoryError, continuing is dangerous.
+
+4. **Cython-generated code**: Cython generates `PyErr_Clear()` in many contexts where it assumes the only possible error is a specific type exception. This is the dominant source of unguarded clears (~25 sites in the Cython runtime alone).
+
+## Analysis Phases
+
+### Phase 1: Automated Scan
+
+Run the PyErr_Clear scanner:
+
+```
+python <plugin_root>/scripts/scan_pyerr_clear.py <target_directory>
+```
+
+Parse the JSON output. Key fields:
+
+- `findings[]`: Each with `type` (`unguarded_pyerr_clear` or `broad_pyerr_clear_in_hot_path`), `function`, `line`, `confidence`
+- `total_pyerr_clear_calls`: Total PyErr_Clear calls found (for context)
+- `summary`: Aggregate statistics
+
+### Phase 2: Prioritized Triage
+
+Triage findings in this order:
+
+1. **`broad_pyerr_clear_in_hot_path`** (HIGH priority): Unguarded clears in frequently-called functions (getters, iterators, hash, contains, subscript). These amplify the danger because they're called many times per operation.
+
+2. **`unguarded_pyerr_clear`** (MEDIUM priority): Unguarded clears in other functions. Read the surrounding code to determine:
+   - What operation preceded the clear? (What error is expected?)
+   - Is there a code path where MemoryError could reach this clear?
+   - Would silently clearing the error cause wrong results or data corruption?
+
+### Phase 3: Deep Analysis
+
+For each finding that survives triage, read the full function and determine:
+
+1. **What exception is the code trying to handle?** Look at the API call before the clear -- what errors can it raise?
+
+2. **Can fatal exceptions reach this clear?** If the preceding call can fail with MemoryError (almost any allocation can), the clear is dangerous.
+
+3. **What happens after the clear?** Does the code continue with a fallback, return a default, or just ignore the error? If it continues, what's the impact of continuing after a MemoryError?
+
+4. **Is this in generated code?** Cython and mypyc generate many unguarded clears. For generated code, note the pattern but recognize that fixes must be made in the code generator, not the generated output.
+
+### Phase 4: Suggested Fixes
+
+For each confirmed finding, suggest a specific fix:
+
+```c
+// Before (dangerous):
+result = PyDict_GetItem(dict, key);
+if (result == NULL) {
+    PyErr_Clear();
+    result = default_value;
+}
+
+// After (safe):
+result = PyDict_GetItemWithError(dict, key);
+if (result == NULL) {
+    if (PyErr_Occurred()) {
+        return NULL;  // propagate MemoryError etc.
+    }
+    result = default_value;
+}
+```
+
+Common fix patterns:
+- Replace `PyDict_GetItem` + `PyErr_Clear` with `PyDict_GetItemWithError` + check
+- Add `PyErr_ExceptionMatches(PyExc_ExpectedType)` guard before clear
+- Replace `PyErr_Clear()` with `if (PyErr_ExceptionMatches(X)) PyErr_Clear(); else return NULL;`
+- For `PyIter_Next` loops: check `PyErr_Occurred()` after NULL instead of clearing
+
+## Output Format
+
+```markdown
+## PyErr_Clear Audit Report
+
+### Summary
+[2-3 sentences: how many PyErr_Clear calls found, how many unguarded, severity assessment]
+
+### Statistics
+- Total PyErr_Clear calls: N
+- Guarded (with ExceptionMatches): N
+- Unguarded: N (N in hot paths)
+
+## Confirmed Findings
+
+### [Finding Title]
+
+- **Location**: `file.c:function_name` (line N)
+- **Classification**: FIX | CONSIDER
+- **Confidence**: HIGH | MEDIUM | LOW
+- **Expected exception**: [what the code intends to handle]
+- **Risk**: [what fatal exceptions could be silently swallowed]
+
+**Code:**
+[relevant code snippet with the unguarded clear]
+
+**Suggested fix:**
+[specific code change]
+
+**Analysis**: [Why this is dangerous, likely impact]
+
+---
+
+## Dismissed Findings
+[Findings that were false positives with brief explanation of why]
+```
+
+## Classification Rules
+
+- **FIX**: PyErr_Clear() can swallow MemoryError or KeyboardInterrupt in a code path that continues execution. The function does not re-raise or check for fatal exceptions afterward.
+- **CONSIDER**: PyErr_Clear() is unguarded but the risk is lower -- either the preceding call rarely fails with OOM, or the function returns soon after anyway, or this is in generated code where the fix must be upstream.
+- **ACCEPTABLE**: The clear is effectively guarded through a mechanism the scanner doesn't detect (e.g., a preceding PyErr_Occurred() check, or the clear is in an error handler that always returns error status).
+
+## Important Guidelines
+
+1. **Almost all API calls can raise MemoryError.** Even `PyDict_GetItem` calls `__hash__` and `__eq__` which can allocate. Any `PyErr_Clear()` after any API call can potentially swallow MemoryError.
+
+2. **PyErr_Occurred() is not a guard.** Checking `PyErr_Occurred()` tells you an exception exists but doesn't tell you what kind. Only `PyErr_ExceptionMatches()` is a proper guard.
+
+3. **Generated code is still worth flagging.** Even though fixes must be upstream, documenting the pattern helps extension authors understand the risk and motivates code generator improvements.
+
+4. **Cap output.** At most 15 confirmed findings. Note totals if more exist.
+
+5. **Cross-reference with error-path-analyzer.** If that agent also flagged exception handling issues, merge the findings. The error-path-analyzer catches exception clobbering; this agent catches exception swallowing.

--- a/plugins/cext-review-toolkit/commands/explore.md
+++ b/plugins/cext-review-toolkit/commands/explore.md
@@ -28,6 +28,7 @@ Parse arguments into three categories:
 - `type-slots` → type-slot-checker
 - `abi` → stable-abi-checker
 - `compat` → version-compat-scanner
+- `pyerr-clear` → pyerr-clear-auditor
 - `complexity` → c-complexity-analyzer
 - `history` → git-history-analyzer
 - `external-tools` → run external tools only (clang-tidy, cppcheck)
@@ -126,16 +127,17 @@ Based on the requested aspects (default: all), launch the appropriate agents. Ea
 **Group C -- Extension correctness**:
 5. module-state-checker
 6. type-slot-checker
+7. pyerr-clear-auditor
 
 **Group D -- Compatibility**:
-7. stable-abi-checker
-8. version-compat-scanner
+8. stable-abi-checker
+9. version-compat-scanner
 
 **Group E -- Code quality**:
-9. c-complexity-analyzer
+10. c-complexity-analyzer
 
 **Group F -- History** (runs last, benefits from all prior findings):
-10. git-history-analyzer
+11. git-history-analyzer
 
 If `parallel` is specified, run agents within each group concurrently (at most `--max-parallel` agents per group, default 2). Groups still execute sequentially.
 

--- a/plugins/cext-review-toolkit/scripts/scan_pyerr_clear.py
+++ b/plugins/cext-review-toolkit/scripts/scan_pyerr_clear.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Audit PyErr_Clear() calls for exception swallowing in C extension code.
+
+Finds PyErr_Clear() calls that are not preceded by PyErr_ExceptionMatches()
+or similar type-checking calls. Unguarded clears silently swallow MemoryError,
+KeyboardInterrupt, and SystemExit — a common and dangerous anti-pattern.
+
+Usage:
+    python scan_pyerr_clear.py [path] [--max-files N]
+"""
+
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from tree_sitter_utils import (
+    parse_bytes_for_file, extract_functions,
+    get_node_text, walk_descendants, strip_comments,
+)
+from scan_common import find_project_root, discover_c_files, parse_common_args
+
+
+# APIs that check the exception type before clearing.
+_EXCEPTION_CHECK_APIS = {
+    "PyErr_ExceptionMatches",
+    "PyErr_GivenExceptionMatches",
+}
+
+# APIs that fetch/inspect the current exception (weaker guard).
+_EXCEPTION_FETCH_APIS = {
+    "PyErr_Fetch",
+    "PyErr_GetRaisedException",
+    "PyErr_GetHandledException",
+}
+
+# Known hot-path function name patterns (heuristic).
+_HOT_PATH_PATTERNS = re.compile(
+    r'(?:get|set|next|iter|contains|subscript|length|item|repr|str|hash|call)',
+    re.IGNORECASE,
+)
+
+
+def _find_pyerr_clear_calls(func: dict, source_bytes: bytes) -> list[dict]:
+    """Find all PyErr_Clear() calls in a function body."""
+    calls = []
+    body_node = func["body_node"]
+    for node in walk_descendants(body_node, type_filter="call_expression"):
+        fn_node = node.child_by_field_name("function")
+        if fn_node and get_node_text(fn_node, source_bytes) == "PyErr_Clear":
+            calls.append({
+                "node": node,
+                "line": node.start_point[0] + 1,
+            })
+    return calls
+
+
+def _has_exception_check_before(clear_node, func: dict,
+                                 source_bytes: bytes) -> bool:
+    """Check if there's a PyErr_ExceptionMatches() guarding a PyErr_Clear().
+
+    Walks up from the clear call to find an enclosing if/else that checks
+    the exception type. Also checks for PyErr_Fetch/GetRaisedException
+    in the same scope (weaker guard but still intentional).
+    """
+    body_text = func["body"]
+    clear_offset = clear_node.start_byte - func["body_node"].start_byte
+
+    # Check the preceding context (up to 500 chars before the clear).
+    start = max(0, clear_offset - 500)
+    preceding = body_text[start:clear_offset]
+
+    # Strong guard: ExceptionMatches check before clear.
+    for api in _EXCEPTION_CHECK_APIS:
+        if api in preceding:
+            return True
+
+    # Medium guard: exception fetch before clear (intentional handling).
+    for api in _EXCEPTION_FETCH_APIS:
+        if api in preceding:
+            return True
+
+    # Walk up the AST to check enclosing if conditions.
+    node = clear_node.parent
+    while node and node != func["body_node"]:
+        if node.type in ("if_statement", "else_clause"):
+            # Check the condition of the if statement.
+            if node.type == "if_statement":
+                cond = node.child_by_field_name("condition")
+                if cond:
+                    cond_text = get_node_text(cond, source_bytes)
+                    for api in _EXCEPTION_CHECK_APIS:
+                        if api in cond_text:
+                            return True
+            # Check if this else belongs to an if with ExceptionMatches.
+            if node.type == "else_clause":
+                parent_if = node.parent
+                if parent_if and parent_if.type == "if_statement":
+                    cond = parent_if.child_by_field_name("condition")
+                    if cond:
+                        cond_text = get_node_text(cond, source_bytes)
+                        for api in _EXCEPTION_CHECK_APIS:
+                            if api in cond_text:
+                                return True
+        node = node.parent
+
+    return False
+
+
+def _is_in_hot_path(func_name: str) -> bool:
+    """Heuristic: check if function name suggests a hot path."""
+    return bool(_HOT_PATH_PATTERNS.search(func_name))
+
+
+def _check_pyerr_clear(func: dict, source_bytes: bytes) -> list[dict]:
+    """Check a function for unguarded PyErr_Clear() calls."""
+    findings = []
+    clear_calls = _find_pyerr_clear_calls(func, source_bytes)
+
+    for call in clear_calls:
+        if _has_exception_check_before(call["node"], func, source_bytes):
+            continue
+
+        is_hot = _is_in_hot_path(func["name"])
+        finding_type = ("broad_pyerr_clear_in_hot_path"
+                        if is_hot else "unguarded_pyerr_clear")
+        confidence = "high" if is_hot else "medium"
+
+        findings.append({
+            "type": finding_type,
+            "file": "",
+            "function": func["name"],
+            "line": call["line"],
+            "confidence": confidence,
+            "detail": (
+                f"PyErr_Clear() in '{func['name']}' without "
+                f"PyErr_ExceptionMatches() guard — silently swallows "
+                f"MemoryError, KeyboardInterrupt, SystemExit"
+            ),
+        })
+
+    return findings
+
+
+def analyze(target: str, *, max_files: int = 0) -> dict:
+    """Scan C files for unguarded PyErr_Clear() calls."""
+    target_path = Path(target).resolve()
+    project_root = find_project_root(target_path)
+    scan_root = target_path if target_path.is_dir() else target_path.parent
+
+    findings: list[dict] = []
+    total_functions = 0
+    total_clears = 0
+    files_analyzed = 0
+    skipped: list[dict] = []
+
+    for filepath in discover_c_files(scan_root, max_files=max_files):
+        try:
+            source_bytes = filepath.read_bytes()
+        except OSError as e:
+            skipped.append({"file": str(filepath), "reason": str(e)})
+            continue
+
+        tree = parse_bytes_for_file(source_bytes, filepath)
+        functions = extract_functions(tree, source_bytes)
+        if not functions:
+            continue
+
+        files_analyzed += 1
+        try:
+            rel = str(filepath.relative_to(project_root))
+        except ValueError:
+            rel = str(filepath)
+
+        for func in functions:
+            total_functions += 1
+            clear_calls = _find_pyerr_clear_calls(func, source_bytes)
+            total_clears += len(clear_calls)
+
+            for f in _check_pyerr_clear(func, source_bytes):
+                f["file"] = rel
+                findings.append(f)
+
+    by_type = defaultdict(int)
+    by_confidence = defaultdict(int)
+    for f in findings:
+        by_type[f["type"]] += 1
+        by_confidence[f["confidence"]] += 1
+
+    return {
+        "project_root": str(project_root),
+        "scan_root": str(scan_root),
+        "functions_analyzed": total_functions,
+        "files_analyzed": files_analyzed,
+        "total_pyerr_clear_calls": total_clears,
+        "findings": findings,
+        "summary": {
+            "total_findings": len(findings),
+            "by_type": dict(by_type),
+            "by_confidence": dict(by_confidence),
+        },
+        "skipped_files": skipped,
+    }
+
+
+def main() -> None:
+    try:
+        target, max_files = parse_common_args(sys.argv[1:])
+        result = analyze(target, max_files=max_files)
+        json.dump(result, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    except Exception as e:
+        json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_scan_pyerr_clear.py
+++ b/tests/test_scan_pyerr_clear.py
@@ -1,0 +1,183 @@
+"""Tests for scan_pyerr_clear.py — PyErr_Clear audit."""
+
+import unittest
+from helpers import import_script, TempExtension, MINIMAL_EXTENSION
+
+pyerr_clear = import_script("scan_pyerr_clear")
+
+
+UNGUARDED_CLEAR = """\
+#include <Python.h>
+
+static PyObject *
+bad_clear(PyObject *self, PyObject *args)
+{
+    PyObject *result = PyDict_GetItem(self, args);
+    if (result == NULL) {
+        PyErr_Clear();  /* BAD: swallows MemoryError */
+        Py_RETURN_NONE;
+    }
+    Py_INCREF(result);
+    return result;
+}
+"""
+
+GUARDED_CLEAR = """\
+#include <Python.h>
+
+static PyObject *
+good_clear(PyObject *self, PyObject *args)
+{
+    PyObject *result = PyDict_GetItem(self, args);
+    if (result == NULL) {
+        if (PyErr_ExceptionMatches(PyExc_KeyError)) {
+            PyErr_Clear();
+            Py_RETURN_NONE;
+        }
+        return NULL;  /* propagate other exceptions */
+    }
+    Py_INCREF(result);
+    return result;
+}
+"""
+
+GUARDED_WITH_FETCH = """\
+#include <Python.h>
+
+static PyObject *
+fetch_clear(PyObject *self, PyObject *args)
+{
+    PyObject *type, *value, *tb;
+    PyErr_Fetch(&type, &value, &tb);
+    /* Intentional: inspecting the exception */
+    PyErr_Clear();
+    Py_XDECREF(type);
+    Py_XDECREF(value);
+    Py_XDECREF(tb);
+    Py_RETURN_NONE;
+}
+"""
+
+HOT_PATH_CLEAR = """\
+#include <Python.h>
+
+static PyObject *
+MyObj_getitem(PyObject *self, PyObject *key)
+{
+    PyObject *result = PyDict_GetItem(self, key);
+    if (result == NULL) {
+        PyErr_Clear();  /* BAD: hot path + swallows MemoryError */
+        Py_RETURN_NONE;
+    }
+    Py_INCREF(result);
+    return result;
+}
+"""
+
+MULTIPLE_CLEARS = """\
+#include <Python.h>
+
+static PyObject *
+multi_clear(PyObject *self, PyObject *args)
+{
+    PyObject *a = PyObject_GetAttrString(self, "a");
+    if (a == NULL) {
+        PyErr_Clear();
+    }
+
+    PyObject *b = PyObject_GetAttrString(self, "b");
+    if (b == NULL) {
+        if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
+            PyErr_Clear();
+        } else {
+            return NULL;
+        }
+    }
+
+    Py_RETURN_NONE;
+}
+"""
+
+NO_CLEAR = """\
+#include <Python.h>
+
+static PyObject *
+clean_function(PyObject *self, PyObject *args)
+{
+    PyObject *result = PyLong_FromLong(42);
+    if (result == NULL)
+        return NULL;
+    return result;
+}
+"""
+
+
+class TestScanPyErrClear(unittest.TestCase):
+    """Test PyErr_Clear audit scanner."""
+
+    def test_unguarded_clear_detected(self):
+        """Unguarded PyErr_Clear is flagged."""
+        with TempExtension({"ext.c": UNGUARDED_CLEAR}) as root:
+            result = pyerr_clear.analyze(str(root / "ext.c"))
+            types = [f["type"] for f in result["findings"]]
+            self.assertIn("unguarded_pyerr_clear", types)
+
+    def test_guarded_clear_not_flagged(self):
+        """PyErr_Clear preceded by ExceptionMatches is not flagged."""
+        with TempExtension({"ext.c": GUARDED_CLEAR}) as root:
+            result = pyerr_clear.analyze(str(root / "ext.c"))
+            self.assertEqual(len(result["findings"]), 0)
+
+    def test_fetch_guard_not_flagged(self):
+        """PyErr_Clear preceded by PyErr_Fetch is not flagged."""
+        with TempExtension({"ext.c": GUARDED_WITH_FETCH}) as root:
+            result = pyerr_clear.analyze(str(root / "ext.c"))
+            self.assertEqual(len(result["findings"]), 0)
+
+    def test_hot_path_higher_severity(self):
+        """Unguarded clear in hot path function has higher severity."""
+        with TempExtension({"ext.c": HOT_PATH_CLEAR}) as root:
+            result = pyerr_clear.analyze(str(root / "ext.c"))
+            types = [f["type"] for f in result["findings"]]
+            self.assertIn("broad_pyerr_clear_in_hot_path", types)
+            hot = [f for f in result["findings"]
+                   if f["type"] == "broad_pyerr_clear_in_hot_path"]
+            self.assertEqual(hot[0]["confidence"], "high")
+
+    def test_multiple_clears_mixed(self):
+        """Multiple clears: only unguarded ones flagged."""
+        with TempExtension({"ext.c": MULTIPLE_CLEARS}) as root:
+            result = pyerr_clear.analyze(str(root / "ext.c"))
+            # First clear is unguarded, second is guarded
+            self.assertEqual(len(result["findings"]), 1)
+            self.assertEqual(result["findings"][0]["function"], "multi_clear")
+
+    def test_no_clear_no_findings(self):
+        """Code without PyErr_Clear has no findings."""
+        with TempExtension({"ext.c": NO_CLEAR}) as root:
+            result = pyerr_clear.analyze(str(root / "ext.c"))
+            self.assertEqual(len(result["findings"]), 0)
+            self.assertEqual(result["total_pyerr_clear_calls"], 0)
+
+    def test_total_clears_counted(self):
+        """Total PyErr_Clear calls are counted correctly."""
+        with TempExtension({"ext.c": MULTIPLE_CLEARS}) as root:
+            result = pyerr_clear.analyze(str(root / "ext.c"))
+            self.assertEqual(result["total_pyerr_clear_calls"], 2)
+
+    def test_output_envelope(self):
+        """Output has correct structure."""
+        with TempExtension({"ext.c": MINIMAL_EXTENSION}) as root:
+            result = pyerr_clear.analyze(str(root / "ext.c"))
+            self.assertIn("project_root", result)
+            self.assertIn("scan_root", result)
+            self.assertIn("functions_analyzed", result)
+            self.assertIn("files_analyzed", result)
+            self.assertIn("total_pyerr_clear_calls", result)
+            self.assertIn("findings", result)
+            self.assertIn("summary", result)
+            self.assertIn("skipped_files", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- New `scan_pyerr_clear.py` script finding unguarded `PyErr_Clear()` calls that silently swallow `MemoryError`, `KeyboardInterrupt`, `SystemExit`
- New `pyerr-clear-auditor` agent for qualitative analysis of dangerous PyErr_Clear patterns
- Integrated into explore command as Group C agent with `pyerr-clear` aspect keyword

This was the dominant bug class found in the Cython runtime (~25 sites) and also appeared in cffi, pandas (ujson), scipy, and mypyc during our analysis of ~15 extensions.

## Test plan
- [x] 8 new tests: unguarded clear, guarded clear (ExceptionMatches), guarded clear (Fetch), hot path severity, mixed clears, no clear, total count, output envelope
- [x] All 119 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)