### PR TITLE
feat: add resource lifecycle scanner and agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `scan_pyerr_clear.py` script: audits PyErr_Clear() calls for unguarded exception swallowing.
 - `pyerr-clear-auditor` agent: qualitative analysis of dangerous PyErr_Clear patterns.
 - `pyerr-clear` aspect keyword in explore command for targeted PyErr_Clear auditing.
+- `scan_resource_lifecycle.py` script: tracks non-PyObject resource allocation/free pairing (malloc/free, HDF5 handles, buffer protocol, file I/O).
+- `resource-lifecycle-checker` agent: qualitative analysis of resource leaks on error paths.
+- `resource_pairs.json` data file: configurable allocation/free pairs for lifecycle tracking (C memory, Python memory, HDF5, buffer protocol, file I/O).
+- `resources` aspect keyword in explore command for targeted resource lifecycle auditing.
 - C++ file support via optional `tree-sitter-cpp` dependency (.cpp, .cxx, .cc files).
 - `run_external_tools.py` script wrapping clang-tidy and cppcheck with JSON envelope output.
 - Phase 0.5 in `explore.md` for automatic external tool baseline.

--- a/plugins/cext-review-toolkit/agents/resource-lifecycle-checker.md
+++ b/plugins/cext-review-toolkit/agents/resource-lifecycle-checker.md
@@ -1,0 +1,148 @@
+---
+name: resource-lifecycle-checker
+description: Use this agent to audit non-PyObject resource lifecycle in C extension code -- malloc/free pairing, HDF5 handle leaks, buffer protocol, and file descriptor management.\n\n<example>\nUser: Check for resource leaks in my C extension.\nAgent: I will run the resource lifecycle scanner, triage each finding for true leaks on error paths, and verify that all allocated resources (memory, file handles, HDF5 objects, buffers) are freed on all exit paths.\n</example>
+model: opus
+color: purple
+---
+
+You are an expert in resource management in C code. Your goal is to find non-PyObject resource leaks in C extension code -- memory from malloc/PyMem_Malloc, HDF5 handles, buffer protocol resources, and file descriptors that are not properly freed on all exit paths (especially error paths).
+
+## Key Concepts
+
+**This agent complements the refcount-auditor.** The refcount-auditor tracks `PyObject*` reference counting. This agent tracks everything else: raw memory, library handles, and protocol resources.
+
+**Error paths are where resource leaks hide.** The happy path usually frees everything. It's the error paths -- early returns after allocation but before cleanup -- where resources leak. The classic pattern:
+
+```c
+// LEAKED on error path:
+buf = malloc(size);
+result = PyUnicode_FromString(buf);
+if (result == NULL) {
+    return NULL;  // BUG: buf leaked!
+}
+free(buf);  // Only reached on success
+return result;
+```
+
+**The goto cleanup pattern is the standard fix:**
+```c
+buf = malloc(size);
+result = PyUnicode_FromString(buf);
+if (result == NULL)
+    goto cleanup;
+// ... success ...
+cleanup:
+    free(buf);
+    return result;
+```
+
+**Resource categories tracked by the scanner:**
+- C memory: `malloc`/`calloc`/`realloc` -> `free`
+- Python memory: `PyMem_Malloc`/`PyMem_Calloc` -> `PyMem_Free`
+- Python object memory: `PyObject_Malloc`/`PyObject_Calloc` -> `PyObject_Free`
+- Buffer protocol: `PyObject_GetBuffer` -> `PyBuffer_Release`
+- HDF5 types: `H5Tcreate`/`H5Tcopy`/`H5Tget_member_type` -> `H5Tclose`
+- HDF5 dataspaces: `H5Screate`/`H5Screate_simple`/`H5Dget_space` -> `H5Sclose`
+- HDF5 datasets/groups/attributes/properties: corresponding create/open -> close
+- File I/O: `fopen` -> `fclose`
+
+## Analysis Phases
+
+### Phase 1: Automated Scan
+
+Run the resource lifecycle scanner:
+
+```
+python <plugin_root>/scripts/scan_resource_lifecycle.py <target_directory>
+```
+
+Parse the JSON output. Key fields:
+
+- `findings[]`: Each with `type` (`resource_never_freed` or `resource_leak_on_error_path`), `variable`, `alloc_func`, `expected_free`, `line`
+- `total_tracked_allocations`: Total allocations found (for context)
+- `summary`: Aggregate statistics
+
+### Phase 2: Prioritized Triage
+
+Triage findings by type:
+
+1. **`resource_never_freed`** (HIGH priority): The resource is allocated and never freed anywhere in the function, and is not returned or stored. This is almost always a real leak.
+
+2. **`resource_leak_on_error_path`** (MEDIUM priority): The resource is freed on the normal path but not on a specific error path. Read the code to verify:
+   - Is the error path actually reachable?
+   - Is the resource freed through a mechanism the scanner doesn't detect (e.g., a wrapper function)?
+   - Would the leak matter in practice (one-time init vs. per-request)?
+
+### Phase 3: Deep Analysis
+
+For each finding that survives triage, read the full function and assess:
+
+1. **Leak magnitude**: Is this a per-call leak (grows with each invocation) or a one-time init leak (bounded)?
+2. **Resource type**: Memory leaks vs. handle leaks. Handle leaks (HDF5, file descriptors) are often worse because the OS has limited handles.
+3. **Error path reachability**: Can the error actually occur? (OOM can always occur, but some API errors are unlikely in practice.)
+4. **Fix pattern**: What's the cleanest fix? goto cleanup, early free, restructure, or use a local variable?
+
+### Phase 4: Cross-Reference
+
+If other agents have run, cross-reference:
+- **error-path-analyzer**: May have found the same error path issue from the exception-handling angle
+- **c-complexity-analyzer**: High-complexity functions are more likely to have leak-prone error paths
+- **git-history-analyzer**: Were similar leaks recently fixed? (Check for fix propagation)
+
+## Output Format
+
+```markdown
+## Resource Lifecycle Report
+
+### Summary
+[2-3 sentences: how many allocations tracked, how many leaks found, severity assessment]
+
+### Statistics
+- Total tracked allocations: N
+- Resources never freed: N
+- Error path leaks: N
+- Resource categories affected: [list]
+
+## Confirmed Leaks
+
+### [Finding Title]
+
+- **Location**: `file.c:function_name` (line N)
+- **Classification**: FIX | CONSIDER
+- **Confidence**: HIGH | MEDIUM | LOW
+- **Resource**: `var` allocated by `alloc_func()`, should be freed by `free_func()`
+- **Leak type**: never freed | leaked on error path at line N
+
+**Code:**
+[relevant code snippet showing the leak]
+
+**Suggested fix:**
+[specific code change -- usually add free() before the error return or use goto cleanup]
+
+**Analysis**: [Why this is a real leak, impact assessment]
+
+---
+
+## Dismissed Findings
+[Findings that were false positives with brief explanation]
+```
+
+## Classification Rules
+
+- **FIX**: Resource is leaked on a reachable error path and the leak grows with each invocation (per-call leak). Memory leaks, handle leaks, and buffer leaks are all FIX.
+- **CONSIDER**: Resource is leaked but the impact is bounded (one-time init) or the error path is extremely unlikely to be reached in practice.
+- **ACCEPTABLE**: Resource is intentionally not freed (stored for later use, returned to caller, or in a function that's only called during module cleanup).
+
+## Important Guidelines
+
+1. **Error paths are the focus.** Don't spend time verifying that the happy path is correct -- it almost always is. Focus on what happens when API calls fail partway through a function.
+
+2. **goto cleanup is not a code smell.** In C resource management, goto cleanup is the standard and correct pattern. Don't suggest refactoring it away.
+
+3. **HDF5 handle leaks are severe.** HDF5 has a finite handle table. Leaked handles accumulate and eventually cause all HDF5 operations to fail. Flag these as HIGH severity.
+
+4. **Buffer protocol leaks cause use-after-free.** A `PyObject_GetBuffer` without `PyBuffer_Release` keeps the buffer locked. The exporter object can't free its data, leading to memory corruption if the object is deallocated while the buffer is still held.
+
+5. **Cap output.** At most 15 confirmed findings. Note totals if more exist.
+
+6. **Custom resource pairs.** The scanner uses `data/resource_pairs.json` for allocation/free mappings. If the extension uses a library with its own resource lifecycle (not already in the file), note what pairs should be added for a more thorough scan.

--- a/plugins/cext-review-toolkit/commands/explore.md
+++ b/plugins/cext-review-toolkit/commands/explore.md
@@ -29,6 +29,7 @@ Parse arguments into three categories:
 - `abi` → stable-abi-checker
 - `compat` → version-compat-scanner
 - `pyerr-clear` → pyerr-clear-auditor
+- `resources` → resource-lifecycle-checker
 - `complexity` → c-complexity-analyzer
 - `history` → git-history-analyzer
 - `external-tools` → run external tools only (clang-tidy, cppcheck)
@@ -123,18 +124,19 @@ Based on the requested aspects (default: all), launch the appropriate agents. Ea
 **Group B -- Memory safety**:
 3. null-safety-scanner
 4. gil-discipline-checker
+5. resource-lifecycle-checker
 
 **Group C -- Extension correctness**:
-5. module-state-checker
-6. type-slot-checker
-7. pyerr-clear-auditor
+6. module-state-checker
+7. type-slot-checker
+8. pyerr-clear-auditor
 
 **Group D -- Compatibility**:
-8. stable-abi-checker
-9. version-compat-scanner
+9. stable-abi-checker
+10. version-compat-scanner
 
 **Group E -- Code quality**:
-10. c-complexity-analyzer
+11. c-complexity-analyzer
 
 **Group F -- History** (runs last, benefits from all prior findings):
 11. git-history-analyzer

--- a/plugins/cext-review-toolkit/data/resource_pairs.json
+++ b/plugins/cext-review-toolkit/data/resource_pairs.json
@@ -1,0 +1,77 @@
+{
+  "description": "Resource allocation/free pairs for lifecycle tracking. Each entry maps an allocation function to its matching free function(s).",
+  "pairs": [
+    {
+      "category": "c_memory",
+      "alloc": ["malloc", "calloc", "realloc", "strdup"],
+      "free": ["free"],
+      "description": "Standard C memory allocation"
+    },
+    {
+      "category": "python_memory",
+      "alloc": ["PyMem_Malloc", "PyMem_Calloc", "PyMem_Realloc"],
+      "free": ["PyMem_Free"],
+      "description": "Python memory allocator (pymalloc)"
+    },
+    {
+      "category": "python_raw_memory",
+      "alloc": ["PyMem_RawMalloc", "PyMem_RawCalloc", "PyMem_RawRealloc"],
+      "free": ["PyMem_RawFree"],
+      "description": "Python raw memory allocator (no GIL required)"
+    },
+    {
+      "category": "python_object_memory",
+      "alloc": ["PyObject_Malloc", "PyObject_Calloc", "PyObject_Realloc"],
+      "free": ["PyObject_Free"],
+      "description": "Python object allocator"
+    },
+    {
+      "category": "buffer_protocol",
+      "alloc": ["PyObject_GetBuffer"],
+      "free": ["PyBuffer_Release"],
+      "description": "Python buffer protocol"
+    },
+    {
+      "category": "hdf5_type",
+      "alloc": ["H5Tcreate", "H5Tcopy", "H5Tget_member_type", "H5Tget_native_type", "H5Tarray_create", "H5Tvlen_create"],
+      "free": ["H5Tclose"],
+      "description": "HDF5 datatype handles"
+    },
+    {
+      "category": "hdf5_space",
+      "alloc": ["H5Screate", "H5Screate_simple", "H5Dget_space", "H5Aget_space", "H5Scopy"],
+      "free": ["H5Sclose"],
+      "description": "HDF5 dataspace handles"
+    },
+    {
+      "category": "hdf5_dataset",
+      "alloc": ["H5Dcreate", "H5Dcreate2", "H5Dopen", "H5Dopen2"],
+      "free": ["H5Dclose"],
+      "description": "HDF5 dataset handles"
+    },
+    {
+      "category": "hdf5_attribute",
+      "alloc": ["H5Acreate", "H5Acreate2", "H5Aopen", "H5Aopen_name"],
+      "free": ["H5Aclose"],
+      "description": "HDF5 attribute handles"
+    },
+    {
+      "category": "hdf5_group",
+      "alloc": ["H5Gcreate", "H5Gcreate2", "H5Gopen", "H5Gopen2"],
+      "free": ["H5Gclose"],
+      "description": "HDF5 group handles"
+    },
+    {
+      "category": "hdf5_property",
+      "alloc": ["H5Pcreate", "H5Pcopy"],
+      "free": ["H5Pclose"],
+      "description": "HDF5 property list handles"
+    },
+    {
+      "category": "file_io",
+      "alloc": ["fopen", "tmpfile"],
+      "free": ["fclose"],
+      "description": "Standard C file I/O"
+    }
+  ]
+}

--- a/plugins/cext-review-toolkit/scripts/scan_resource_lifecycle.py
+++ b/plugins/cext-review-toolkit/scripts/scan_resource_lifecycle.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Track non-PyObject resource allocation/free pairing in C extension code.
+
+Finds allocations (malloc, PyMem_Malloc, H5Tcreate, PyObject_GetBuffer, etc.)
+that may not have a matching free on all exit paths. This catches resource leaks
+on error paths — the most impactful bug class found in h5py, scipy, and pandas.
+
+Usage:
+    python scan_resource_lifecycle.py [path] [--max-files N]
+"""
+
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from tree_sitter_utils import (
+    parse_bytes_for_file, extract_functions, find_calls_in_scope,
+    find_return_statements, get_node_text, walk_descendants,
+    strip_comments,
+)
+from scan_common import (
+    find_project_root, discover_c_files, find_assigned_variable,
+    parse_common_args,
+)
+
+
+_DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+
+
+def _load_resource_pairs() -> dict[str, list[str]]:
+    """Load resource allocation/free pairs from data file.
+
+    Returns a dict mapping alloc function name -> list of valid free functions.
+    """
+    pairs_file = _DATA_DIR / "resource_pairs.json"
+    try:
+        with open(pairs_file, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+    alloc_to_free: dict[str, list[str]] = {}
+    for pair in data.get("pairs", []):
+        free_funcs = pair.get("free", [])
+        for alloc_func in pair.get("alloc", []):
+            alloc_to_free[alloc_func] = free_funcs
+    return alloc_to_free
+
+
+def _find_allocations(func: dict, source_bytes: bytes,
+                      alloc_to_free: dict[str, list[str]]) -> list[dict]:
+    """Find resource allocation calls in a function and their assigned variables."""
+    allocations = []
+    body = func["body_node"]
+    alloc_names = set(alloc_to_free.keys())
+
+    all_calls = find_calls_in_scope(body, source_bytes, api_names=alloc_names)
+    for call in all_calls:
+        var_name = find_assigned_variable(call["node"], source_bytes)
+        if not var_name:
+            continue
+
+        alloc_func = call["function_name"]
+        free_funcs = alloc_to_free.get(alloc_func, [])
+
+        allocations.append({
+            "variable": var_name,
+            "alloc_func": alloc_func,
+            "free_funcs": free_funcs,
+            "line": call["start_line"],
+            "call_node": call["node"],
+        })
+
+    return allocations
+
+
+def _find_free_calls(func: dict, source_bytes: bytes,
+                     free_funcs: set[str]) -> list[dict]:
+    """Find all free/release/close calls in a function."""
+    body = func["body_node"]
+    all_calls = find_calls_in_scope(body, source_bytes, api_names=free_funcs)
+    result = []
+    for call in all_calls:
+        args_text = call.get("arguments_text", "")
+        result.append({
+            "function_name": call["function_name"],
+            "arguments_text": args_text,
+            "line": call["start_line"],
+        })
+    return result
+
+
+def _find_goto_labels(func: dict, source_bytes: bytes) -> dict[str, int]:
+    """Find all goto labels in a function and their line numbers."""
+    labels = {}
+    body = func["body_node"]
+    for node in walk_descendants(body, "labeled_statement"):
+        label_node = node.child_by_field_name("label")
+        if label_node:
+            label_name = get_node_text(label_node, source_bytes)
+            labels[label_name] = node.start_point[0] + 1
+    return labels
+
+
+def _find_exit_points(func: dict, source_bytes: bytes) -> list[dict]:
+    """Find all function exit points (return statements and goto error labels)."""
+    exits = []
+    body = func["body_node"]
+
+    # Return statements.
+    returns = find_return_statements(body, source_bytes)
+    for ret in returns:
+        value = ret.get("value_text") or ""
+        exits.append({
+            "type": "return",
+            "line": ret["start_line"],
+            "value": value,
+            "is_error": _is_error_return(value),
+        })
+
+    return exits
+
+
+def _is_error_return(value: str) -> bool:
+    """Check if a return value indicates an error (NULL, -1, etc.)."""
+    v = value.strip()
+    return v in ("NULL", "-1", "0") or v == ""
+
+
+def _variable_freed_in_text(var_name: str, free_funcs: list[str],
+                             text: str) -> bool:
+    """Check if a variable is freed in a given text span."""
+    for free_func in free_funcs:
+        # Match free_func(var) or free_func(&var) or free_func(self->var)
+        pattern = rf'{re.escape(free_func)}\s*\([^)]*\b{re.escape(var_name)}\b'
+        if re.search(pattern, text):
+            return True
+    return False
+
+
+def _check_resource_lifecycle(func: dict, source_bytes: bytes,
+                               alloc_to_free: dict[str, list[str]]) -> list[dict]:
+    """Check that all allocated resources are freed on all exit paths."""
+    findings = []
+    allocations = _find_allocations(func, source_bytes, alloc_to_free)
+
+    if not allocations:
+        return findings
+
+    body_text = strip_comments(func["body"])
+    exits = _find_exit_points(func, source_bytes)
+
+    # Collect all free function names for lookup.
+    all_free_funcs: set[str] = set()
+    for alloc in allocations:
+        all_free_funcs.update(alloc["free_funcs"])
+
+    for alloc in allocations:
+        var = alloc["variable"]
+        free_funcs = alloc["free_funcs"]
+        alloc_line = alloc["line"]
+
+        if not free_funcs:
+            continue
+
+        # Check: is the variable freed at all in the function?
+        freed_anywhere = _variable_freed_in_text(var, free_funcs, body_text)
+
+        if not freed_anywhere:
+            # Resource never freed in this function — might be stored or returned.
+            # Check if variable is returned or stored in a struct.
+            if _is_returned_or_stored(var, body_text):
+                continue
+
+            findings.append({
+                "type": "resource_never_freed",
+                "file": "",
+                "function": func["name"],
+                "line": alloc_line,
+                "confidence": "high",
+                "detail": (f"Resource '{var}' allocated by {alloc['alloc_func']}() "
+                           f"is never freed by {'/'.join(free_funcs)}() "
+                           f"in function '{func['name']}'"),
+                "variable": var,
+                "alloc_func": alloc["alloc_func"],
+                "expected_free": free_funcs,
+            })
+            continue
+
+        # Resource IS freed somewhere — check if it's freed on error paths too.
+        # Look at each exit point: is there a free before it?
+        for exit_point in exits:
+            if not exit_point["is_error"]:
+                continue
+
+            exit_line = exit_point["line"]
+            if exit_line <= alloc_line:
+                continue  # Exit is before the allocation.
+
+            # Get the text between allocation and this exit.
+            alloc_offset = _line_to_offset(body_text, alloc_line - func["start_line"])
+            exit_offset = _line_to_offset(body_text, exit_line - func["start_line"])
+
+            if alloc_offset is None or exit_offset is None:
+                continue
+
+            span = body_text[alloc_offset:exit_offset]
+
+            # Skip error returns that are the NULL check for this allocation
+            # itself (the resource doesn't exist on this path).
+            if _is_null_check_for_alloc(var, alloc_line, exit_line,
+                                         body_text, func["start_line"]):
+                continue
+
+            # Check if the variable is freed in this span.
+            if not _variable_freed_in_text(var, free_funcs, span):
+                # Also check if there's a goto to a cleanup label that frees it.
+                if _has_goto_cleanup_freeing(var, free_funcs, span, body_text):
+                    continue
+
+                findings.append({
+                    "type": "resource_leak_on_error_path",
+                    "file": "",
+                    "function": func["name"],
+                    "line": exit_line,
+                    "confidence": "medium",
+                    "detail": (f"Resource '{var}' (allocated at line {alloc_line} "
+                               f"by {alloc['alloc_func']}()) may not be freed "
+                               f"before error return at line {exit_line}"),
+                    "variable": var,
+                    "alloc_func": alloc["alloc_func"],
+                    "alloc_line": alloc_line,
+                    "expected_free": free_funcs,
+                })
+
+    return findings
+
+
+def _line_to_offset(text: str, line_delta: int) -> int | None:
+    """Convert a line delta to a byte offset in text."""
+    offset = 0
+    for _ in range(line_delta):
+        idx = text.find("\n", offset)
+        if idx == -1:
+            return None
+        offset = idx + 1
+    return offset
+
+
+def _is_returned_or_stored(var: str, body_text: str) -> bool:
+    """Check if a variable is returned directly or stored in a struct member."""
+    # Check for direct return: return var; or return (type*)var;
+    # But NOT return func(var) — that's passing as argument, not returning.
+    if re.search(rf'\breturn\s+(?:\([^)]*\)\s*)?{re.escape(var)}\s*;', body_text):
+        return True
+    # Check for struct member assignment: self->field = var or obj.field = var.
+    if re.search(rf'->\w+\s*=\s*(?:\([^)]*\)\s*)?{re.escape(var)}\s*;', body_text):
+        return True
+    if re.search(rf'\.\w+\s*=\s*(?:\([^)]*\)\s*)?{re.escape(var)}\s*;', body_text):
+        return True
+    return False
+
+
+def _is_null_check_for_alloc(var: str, alloc_line: int, exit_line: int,
+                             full_body: str, func_start_line: int) -> bool:
+    """Check if the error return is inside a NULL check for the allocated variable.
+
+    E.g., the error return in: if (buf == NULL) { return NULL; }
+    The resource doesn't exist here, so this isn't a leak.
+
+    The check must be within 3 lines after the allocation for it to be
+    considered the allocation's own null check (not a later check).
+    """
+    # Get the text from 1 line before alloc to 4 lines after alloc.
+    # The if-check typically follows on the next line after the allocation.
+    check_start = max(0, alloc_line - func_start_line - 1)
+    check_end = min(alloc_line - func_start_line + 4,
+                    full_body.count("\n") + 1)
+
+    start_offset = _line_to_offset(full_body, check_start)
+    end_offset = _line_to_offset(full_body, check_end)
+    if start_offset is None:
+        start_offset = 0
+    if end_offset is None:
+        end_offset = len(full_body)
+
+    context = full_body[start_offset:end_offset]
+
+    # Only suppress if the error return is within this narrow window.
+    if not (alloc_line <= exit_line <= alloc_line + 4):
+        return False
+
+    patterns = [
+        rf'\bif\s*\(\s*!\s*{re.escape(var)}\s*\)',
+        rf'\bif\s*\(\s*{re.escape(var)}\s*==\s*NULL\s*\)',
+        rf'\bif\s*\(\s*{re.escape(var)}\s*==\s*0\s*\)',
+        rf'\bif\s*\(\s*{re.escape(var)}\s*<\s*0\s*\)',
+    ]
+    return any(re.search(p, context) for p in patterns)
+
+
+def _has_goto_cleanup_freeing(var: str, free_funcs: list[str],
+                               span: str, full_body: str) -> bool:
+    """Check if the span contains a goto to a cleanup label that frees var."""
+    goto_matches = re.finditer(r'\bgoto\s+(\w+)', span)
+    for m in goto_matches:
+        label = m.group(1)
+        # Find text after the label in the full body.
+        label_pattern = rf'\b{re.escape(label)}\s*:'
+        label_match = re.search(label_pattern, full_body)
+        if label_match:
+            cleanup_text = full_body[label_match.end():]
+            if _variable_freed_in_text(var, free_funcs, cleanup_text):
+                return True
+    return False
+
+
+def analyze(target: str, *, max_files: int = 0) -> dict:
+    """Scan C files for resource lifecycle issues."""
+    target_path = Path(target).resolve()
+    project_root = find_project_root(target_path)
+    scan_root = target_path if target_path.is_dir() else target_path.parent
+
+    alloc_to_free = _load_resource_pairs()
+
+    findings: list[dict] = []
+    total_functions = 0
+    total_allocations = 0
+    files_analyzed = 0
+    skipped: list[dict] = []
+
+    for filepath in discover_c_files(scan_root, max_files=max_files):
+        try:
+            source_bytes = filepath.read_bytes()
+        except OSError as e:
+            skipped.append({"file": str(filepath), "reason": str(e)})
+            continue
+
+        tree = parse_bytes_for_file(source_bytes, filepath)
+        functions = extract_functions(tree, source_bytes)
+        if not functions:
+            continue
+
+        files_analyzed += 1
+        try:
+            rel = str(filepath.relative_to(project_root))
+        except ValueError:
+            rel = str(filepath)
+
+        for func in functions:
+            total_functions += 1
+            allocs = _find_allocations(func, source_bytes, alloc_to_free)
+            total_allocations += len(allocs)
+
+            for f in _check_resource_lifecycle(func, source_bytes, alloc_to_free):
+                f["file"] = rel
+                findings.append(f)
+
+    by_type = defaultdict(int)
+    by_confidence = defaultdict(int)
+    for f in findings:
+        by_type[f["type"]] += 1
+        by_confidence[f["confidence"]] += 1
+
+    return {
+        "project_root": str(project_root),
+        "scan_root": str(scan_root),
+        "functions_analyzed": total_functions,
+        "files_analyzed": files_analyzed,
+        "total_tracked_allocations": total_allocations,
+        "findings": findings,
+        "summary": {
+            "total_findings": len(findings),
+            "by_type": dict(by_type),
+            "by_confidence": dict(by_confidence),
+        },
+        "skipped_files": skipped,
+    }
+
+
+def main() -> None:
+    try:
+        target, max_files = parse_common_args(sys.argv[1:])
+        result = analyze(target, max_files=max_files)
+        json.dump(result, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    except Exception as e:
+        json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_scan_resource_lifecycle.py
+++ b/tests/test_scan_resource_lifecycle.py
@@ -1,0 +1,223 @@
+"""Tests for scan_resource_lifecycle.py — resource allocation/free tracking."""
+
+import unittest
+from helpers import import_script, TempExtension, MINIMAL_EXTENSION
+
+lifecycle = import_script("scan_resource_lifecycle")
+
+
+MALLOC_NEVER_FREED = """\
+#include <Python.h>
+#include <stdlib.h>
+
+static PyObject *
+leaky_malloc(PyObject *self, PyObject *args)
+{
+    char *buf = malloc(1024);
+    if (buf == NULL) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+    /* BUG: buf is never freed */
+    return PyUnicode_FromString(buf);
+}
+"""
+
+MALLOC_FREED_CORRECTLY = """\
+#include <Python.h>
+#include <stdlib.h>
+
+static PyObject *
+good_malloc(PyObject *self, PyObject *args)
+{
+    char *buf = malloc(1024);
+    if (buf == NULL) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+    PyObject *result = PyUnicode_FromString(buf);
+    free(buf);
+    return result;
+}
+"""
+
+MALLOC_LEAK_ON_ERROR = """\
+#include <Python.h>
+#include <stdlib.h>
+
+static PyObject *
+error_leak(PyObject *self, PyObject *args)
+{
+    char *buf = malloc(1024);
+    if (buf == NULL) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+    PyObject *result = PyUnicode_FromString(buf);
+    if (result == NULL) {
+        /* BUG: buf leaked on this error path */
+        return NULL;
+    }
+    free(buf);
+    return result;
+}
+"""
+
+GOTO_CLEANUP = """\
+#include <Python.h>
+#include <stdlib.h>
+
+static PyObject *
+goto_cleanup(PyObject *self, PyObject *args)
+{
+    char *buf = malloc(1024);
+    if (buf == NULL) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+    PyObject *result = PyUnicode_FromString(buf);
+    if (result == NULL) {
+        goto cleanup;
+    }
+    free(buf);
+    return result;
+
+cleanup:
+    free(buf);
+    return NULL;
+}
+"""
+
+PYMEM_MALLOC = """\
+#include <Python.h>
+
+static PyObject *
+pymem_leak(PyObject *self, PyObject *args)
+{
+    char *buf = PyMem_Malloc(256);
+    if (buf == NULL) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+    /* BUG: PyMem_Free never called */
+    return PyLong_FromLong(42);
+}
+"""
+
+BUFFER_PROTOCOL = """\
+#include <Python.h>
+
+static PyObject *
+buffer_leak(PyObject *self, PyObject *args)
+{
+    PyObject *obj;
+    if (!PyArg_ParseTuple(args, "O", &obj))
+        return NULL;
+
+    Py_buffer view;
+    int result = PyObject_GetBuffer(obj, &view, PyBUF_SIMPLE);
+    if (result < 0)
+        return NULL;
+
+    /* BUG: PyBuffer_Release never called */
+    return PyLong_FromLong(view.len);
+}
+"""
+
+RESOURCE_RETURNED = """\
+#include <Python.h>
+#include <stdlib.h>
+
+static char *
+make_buffer(int size)
+{
+    char *buf = malloc(size);
+    return buf;  /* Ownership transferred to caller */
+}
+"""
+
+
+class TestScanResourceLifecycle(unittest.TestCase):
+    """Test resource lifecycle tracking."""
+
+    def test_malloc_never_freed(self):
+        """Detect malloc'd buffer never freed."""
+        with TempExtension({"ext.c": MALLOC_NEVER_FREED}) as root:
+            result = lifecycle.analyze(str(root / "ext.c"))
+            types = [f["type"] for f in result["findings"]]
+            self.assertIn("resource_never_freed", types)
+            finding = [f for f in result["findings"]
+                       if f["type"] == "resource_never_freed"][0]
+            self.assertEqual(finding["variable"], "buf")
+            self.assertEqual(finding["alloc_func"], "malloc")
+
+    def test_malloc_freed_no_finding(self):
+        """Correctly freed malloc produces no finding."""
+        with TempExtension({"ext.c": MALLOC_FREED_CORRECTLY}) as root:
+            result = lifecycle.analyze(str(root / "ext.c"))
+            self.assertEqual(len(result["findings"]), 0)
+
+    def test_malloc_leak_on_error_path(self):
+        """Detect malloc leak on error return path."""
+        with TempExtension({"ext.c": MALLOC_LEAK_ON_ERROR}) as root:
+            result = lifecycle.analyze(str(root / "ext.c"))
+            leak_findings = [f for f in result["findings"]
+                             if f["type"] == "resource_leak_on_error_path"]
+            self.assertGreater(len(leak_findings), 0)
+            self.assertEqual(leak_findings[0]["variable"], "buf")
+
+    def test_goto_cleanup_no_finding(self):
+        """Goto cleanup that frees the resource is not flagged."""
+        with TempExtension({"ext.c": GOTO_CLEANUP}) as root:
+            result = lifecycle.analyze(str(root / "ext.c"))
+            leak_findings = [f for f in result["findings"]
+                             if f["type"] == "resource_leak_on_error_path"]
+            self.assertEqual(len(leak_findings), 0)
+
+    def test_pymem_malloc_detected(self):
+        """Detect PyMem_Malloc without PyMem_Free."""
+        with TempExtension({"ext.c": PYMEM_MALLOC}) as root:
+            result = lifecycle.analyze(str(root / "ext.c"))
+            types = [f["type"] for f in result["findings"]]
+            self.assertIn("resource_never_freed", types)
+            finding = [f for f in result["findings"]
+                       if f["type"] == "resource_never_freed"][0]
+            self.assertEqual(finding["alloc_func"], "PyMem_Malloc")
+
+    def test_buffer_protocol_detected(self):
+        """Detect PyObject_GetBuffer without PyBuffer_Release."""
+        with TempExtension({"ext.c": BUFFER_PROTOCOL}) as root:
+            result = lifecycle.analyze(str(root / "ext.c"))
+            types = [f["type"] for f in result["findings"]]
+            self.assertIn("resource_never_freed", types)
+
+    def test_returned_resource_not_flagged(self):
+        """Resource that is returned is not flagged as leaked."""
+        with TempExtension({"ext.c": RESOURCE_RETURNED}) as root:
+            result = lifecycle.analyze(str(root / "ext.c"))
+            never_freed = [f for f in result["findings"]
+                           if f["type"] == "resource_never_freed"]
+            self.assertEqual(len(never_freed), 0)
+
+    def test_allocation_count(self):
+        """Total tracked allocations are counted."""
+        with TempExtension({"ext.c": MALLOC_LEAK_ON_ERROR}) as root:
+            result = lifecycle.analyze(str(root / "ext.c"))
+            self.assertGreater(result["total_tracked_allocations"], 0)
+
+    def test_output_envelope(self):
+        """Output has correct structure."""
+        with TempExtension({"ext.c": MINIMAL_EXTENSION}) as root:
+            result = lifecycle.analyze(str(root / "ext.c"))
+            self.assertIn("project_root", result)
+            self.assertIn("scan_root", result)
+            self.assertIn("functions_analyzed", result)
+            self.assertIn("files_analyzed", result)
+            self.assertIn("total_tracked_allocations", result)
+            self.assertIn("findings", result)
+            self.assertIn("summary", result)
+            self.assertIn("skipped_files", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- New `scan_resource_lifecycle.py` script tracking non-PyObject resource allocation/free pairing
- New `resource-lifecycle-checker` agent for qualitative analysis of resource leaks
- New `resource_pairs.json` data file with configurable allocation/free pairs (C memory, Python memory, HDF5, buffer protocol, file I/O)
- Integrated into explore command as Group B agent with `resources` aspect keyword

Catches the most impactful bug class found across h5py (5 HDF5 handle leaks), scipy (6+ malloc leaks), and pandas (use-after-free in int64ToIso).

## Test plan
- [x] 9 new tests: malloc never freed, malloc freed correctly, malloc leak on error path, goto cleanup, PyMem_Malloc, buffer protocol, returned resource, allocation count, output envelope
- [x] All 120 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)