### PR TITLE
feat: add tp_init re-init safety and tp_new member initialization checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Enhanced
 - `type-slot-checker` agent: added immutable-type exception for missing `tp_clear`. Types whose `PyObject*` members are set once during construction and never mutated are now classified as ACCEPTABLE (not CONSIDER) when missing `tp_clear`, matching CPython's own convention.
+- `type-slot-checker` agent and `scan_type_slots.py`: added two new checks based on APSW maintainer feedback:
+  - `init_not_reinit_safe`: detects `tp_init` that allocates resources without checking/cleaning prior state. Python allows calling `__init__()` multiple times, so a second call leaks the first call's resources.
+  - `new_missing_member_init`: detects `tp_new` that uses a non-zeroing allocator without initializing pointer members. Python allows `__new__()` without `__init__()`, so methods may dereference uninitialized pointers.
+- `tree_sitter_utils.py`: `find_struct_members` now returns `is_pointer` field for struct member dicts.
 
 ## [0.1.2] - 2026-03-25
 

--- a/plugins/cext-review-toolkit/agents/type-slot-checker.md
+++ b/plugins/cext-review-toolkit/agents/type-slot-checker.md
@@ -40,6 +40,8 @@ Collect all findings and organize by type:
 | `missing_gc_flag` | MEDIUM | Type has PyObject* members but no Py_TPFLAGS_HAVE_GC |
 | `heap_type_missing_type_decref` | HIGH | Heap type tp_dealloc does not Py_DECREF(Py_TYPE(self)) |
 | `type_spec_missing_sentinel` | CRITICAL | PyType_Slot array not terminated with {0, NULL} |
+| `init_not_reinit_safe` | HIGH | tp_init allocates resources without checking/cleaning prior state -- second __init__() call leaks |
+| `new_missing_member_init` | MEDIUM | tp_new uses non-zeroing allocator without initializing pointer members -- __new__() without __init__() leaves dangling pointers |
 
 For each finding:
 1. Read the type's struct definition to understand all members.
@@ -86,9 +88,10 @@ For each type defined in the extension, perform a comprehensive slot audit:
    - If `Py_TPFLAGS_HAVE_GC` is set, objects must be allocated with `PyObject_GC_New` and tracked with `PyObject_GC_Track`.
    - If `Py_TPFLAGS_HAVE_GC` is NOT set, objects must NOT be allocated with GC functions.
 
-6. **tp_new / tp_init review**:
-   - Does `tp_new` allocate the object correctly (using `tp_alloc`)?
-   - Does `tp_init` properly handle being called multiple times on the same object?
+6. **tp_new / tp_init review** (critical for C extensions — Python allows calling patterns impossible in C++):
+   - Does `tp_new` allocate the object correctly (using `tp_alloc` which zeros memory)?
+   - Does `tp_new` initialize ALL pointer members to NULL/safe defaults? Python allows `object.__new__(MyType)` without calling `__init__`, so methods may be called on objects where `tp_init` never ran. If `tp_new` doesn't zero pointers, methods that assume `tp_init` ran will dereference uninitialized garbage.
+   - Does `tp_init` properly handle being called multiple times on the same object? Python allows `obj.__init__()` to be called again after construction. If `tp_init` allocates resources (malloc, PyObject_New, fopen, etc.) without first cleaning up existing state, the second call leaks the first call's resources. The fix is either: (a) reject re-init (`if (self->initialized) { PyErr_SetString(...); return -1; }`), or (b) clean up first (run destructor-like logic before re-initializing).
    - For GC types: is `PyObject_GC_Track` called after initialization is complete?
 
 7. **tp_richcompare review**:
@@ -128,7 +131,7 @@ For each confirmed or likely finding, produce a structured entry:
 
 - **File**: `path/to/file.c`
 - **Line(s)**: 123-145
-- **Type**: dealloc_missing_tp_free | dealloc_wrong_free | dealloc_missing_untrack | traverse_missing_member | richcompare_not_incref_notimplemented | missing_gc_flag | heap_type_missing_type_decref | type_spec_missing_sentinel
+- **Type**: dealloc_missing_tp_free | dealloc_wrong_free | dealloc_missing_untrack | traverse_missing_member | richcompare_not_incref_notimplemented | missing_gc_flag | heap_type_missing_type_decref | type_spec_missing_sentinel | init_not_reinit_safe | new_missing_member_init
 - **Classification**: FIX | CONSIDER | POLICY
 - **Confidence**: HIGH | MEDIUM | LOW
 - **Affected Type**: `MyType` (struct `MyTypeObject`)
@@ -147,8 +150,8 @@ For each confirmed or likely finding, produce a structured entry:
 
 ## Classification Rules
 
-- **FIX**: Missing `tp_free` call in `tp_dealloc` (memory leak on every object destruction). `tp_traverse` that does not visit a `PyObject*` member (GC cannot detect cycles, leading to memory leaks). Returning `Py_NotImplemented` without `Py_INCREF` (refcount corruption). Missing `{0, NULL}` sentinel in `PyType_Slot` array (buffer overread, undefined behavior). Missing `Py_DECREF(Py_TYPE(self))` in heap type dealloc (type object leak).
-- **CONSIDER**: Missing `Py_TPFLAGS_HAVE_GC` when the type has `PyObject*` members that could create cycles (potential memory leak if cycles form). Wrong `tp_free` function for a non-subclassable type (works but fragile). Missing `PyObject_GC_UnTrack` in dealloc (potential GC visiting half-destroyed object). Missing `tp_clear` on a GC type with **mutable** `PyObject*` members (GC can detect cycles but cannot break them).
+- **FIX**: Missing `tp_free` call in `tp_dealloc` (memory leak on every object destruction). `tp_traverse` that does not visit a `PyObject*` member (GC cannot detect cycles, leading to memory leaks). Returning `Py_NotImplemented` without `Py_INCREF` (refcount corruption). Missing `{0, NULL}` sentinel in `PyType_Slot` array (buffer overread, undefined behavior). Missing `Py_DECREF(Py_TYPE(self))` in heap type dealloc (type object leak). `tp_init` that allocates resources without re-init guard (resource leak on second `__init__()` call).
+- **CONSIDER**: Missing `Py_TPFLAGS_HAVE_GC` when the type has `PyObject*` members that could create cycles (potential memory leak if cycles form). Wrong `tp_free` function for a non-subclassable type (works but fragile). Missing `PyObject_GC_UnTrack` in dealloc (potential GC visiting half-destroyed object). Missing `tp_clear` on a GC type with **mutable** `PyObject*` members (GC can detect cycles but cannot break them). `tp_new` that uses a non-zeroing allocator without initializing pointer members (`__new__()` without `__init__()` leaves dangling pointers).
 - **ACCEPTABLE**: Missing `tp_clear` on a GC type whose `PyObject*` members are **immutable after construction** (set once in `tp_new`/`tp_init`, never mutated). CPython itself omits `tp_clear` for such types. See the immutable-type exception in the tp_clear review section.
 - **POLICY**: Whether to use heap types vs static types. Whether to make a type GC-capable when cycles are unlikely but possible. Whether to support subclassing (`Py_TPFLAGS_BASETYPE`).
 

--- a/plugins/cext-review-toolkit/scripts/scan_type_slots.py
+++ b/plugins/cext-review-toolkit/scripts/scan_type_slots.py
@@ -16,9 +16,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from tree_sitter_utils import (
-    parse_bytes_for_file, extract_functions, find_calls_in_scope,
-    extract_struct_initializers, find_struct_members,
-    get_node_text, walk_descendants, strip_comments,
+    parse_bytes_for_file,
+    extract_functions,
+    extract_struct_initializers,
+    find_struct_members,
+    strip_comments,
 )
 from scan_common import find_project_root, discover_c_files, parse_common_args
 
@@ -34,7 +36,7 @@ def _find_func_by_name(functions: list[dict], name: str) -> dict | None:
 def _parse_type_fields(init_text: str) -> dict[str, str]:
     """Parse PyTypeObject designated initializer fields."""
     fields = {}
-    for m in re.finditer(r'\.(\w+)\s*=\s*([^,}]+)', init_text):
+    for m in re.finditer(r"\.(\w+)\s*=\s*([^,}]+)", init_text):
         fields[m.group(1)] = m.group(2).strip()
     return fields
 
@@ -42,22 +44,25 @@ def _parse_type_fields(init_text: str) -> dict[str, str]:
 def _parse_type_slots_array(init_text: str) -> list[tuple[str, str]]:
     """Parse PyType_Slot array entries like {Py_tp_dealloc, func}."""
     slots = []
-    for m in re.finditer(r'\{\s*(\w+)\s*,\s*([^}]+)\}', init_text):
+    for m in re.finditer(r"\{\s*(\w+)\s*,\s*([^}]+)\}", init_text):
         slots.append((m.group(1).strip(), m.group(2).strip()))
     return slots
 
 
-def _get_struct_name_from_type(type_fields: dict[str, str], source_text: str) -> str | None:
+def _get_struct_name_from_type(
+    type_fields: dict[str, str], source_text: str
+) -> str | None:
     """Try to extract the C struct name from tp_basicsize = sizeof(StructName)."""
     basicsize = type_fields.get("tp_basicsize", "")
-    m = re.search(r'sizeof\s*\(\s*(\w+)\s*\)', basicsize)
+    m = re.search(r"sizeof\s*\(\s*(\w+)\s*\)", basicsize)
     if m:
         return m.group(1)
     return None
 
 
-def _check_dealloc(type_info: dict, functions: list[dict],
-                    source_bytes: bytes, source_text: str):
+def _check_dealloc(
+    type_info: dict, functions: list[dict], source_bytes: bytes, source_text: str
+):
     """Check tp_dealloc function for correctness."""
     findings = []
     dealloc_name = type_info.get("dealloc_func")
@@ -65,7 +70,7 @@ def _check_dealloc(type_info: dict, functions: list[dict],
         return findings
 
     # Strip casts like (destructor).
-    dealloc_name = re.sub(r'\([^)]*\)\s*', '', dealloc_name).strip()
+    dealloc_name = re.sub(r"\([^)]*\)\s*", "", dealloc_name).strip()
     dealloc_func = _find_func_by_name(functions, dealloc_name)
     if not dealloc_func:
         return findings
@@ -78,42 +83,54 @@ def _check_dealloc(type_info: dict, functions: list[dict],
     has_pyobject_del = "PyObject_Del" in body_text or "PyObject_Free" in body_text
 
     if not has_tp_free and not has_pyobject_del:
-        findings.append({
-            "type": "dealloc_missing_tp_free",
-            "file": "",
-            "function": dealloc_name,
-            "line": dealloc_func["start_line"],
-            "confidence": "high",
-            "detail": (f"tp_dealloc '{dealloc_name}' doesn't call tp_free "
-                       f"or any free function — memory leak"),
-            "type_name": type_info["name"],
-        })
+        findings.append(
+            {
+                "type": "dealloc_missing_tp_free",
+                "file": "",
+                "function": dealloc_name,
+                "line": dealloc_func["start_line"],
+                "confidence": "high",
+                "detail": (
+                    f"tp_dealloc '{dealloc_name}' doesn't call tp_free "
+                    f"or any free function — memory leak"
+                ),
+                "type_name": type_info["name"],
+            }
+        )
 
     if has_pyobject_del and not has_tp_free:
-        findings.append({
-            "type": "dealloc_wrong_free",
-            "file": "",
-            "function": dealloc_name,
-            "line": dealloc_func["start_line"],
-            "confidence": "medium",
-            "detail": (f"tp_dealloc '{dealloc_name}' uses PyObject_Del/Free "
-                       f"instead of Py_TYPE(self)->tp_free — breaks inheritance"),
-            "type_name": type_info["name"],
-        })
+        findings.append(
+            {
+                "type": "dealloc_wrong_free",
+                "file": "",
+                "function": dealloc_name,
+                "line": dealloc_func["start_line"],
+                "confidence": "medium",
+                "detail": (
+                    f"tp_dealloc '{dealloc_name}' uses PyObject_Del/Free "
+                    f"instead of Py_TYPE(self)->tp_free — breaks inheritance"
+                ),
+                "type_name": type_info["name"],
+            }
+        )
 
     # Check for GC untrack (body_text already has comments stripped).
     if has_gc and "PyObject_GC_UnTrack" not in body_text:
-        findings.append({
-            "type": "dealloc_missing_untrack",
-            "file": "",
-            "function": dealloc_name,
-            "line": dealloc_func["start_line"],
-            "confidence": "high",
-            "detail": (f"Type has Py_TPFLAGS_HAVE_GC but tp_dealloc "
-                       f"'{dealloc_name}' doesn't call "
-                       f"PyObject_GC_UnTrack"),
-            "type_name": type_info["name"],
-        })
+        findings.append(
+            {
+                "type": "dealloc_missing_untrack",
+                "file": "",
+                "function": dealloc_name,
+                "line": dealloc_func["start_line"],
+                "confidence": "high",
+                "detail": (
+                    f"Type has Py_TPFLAGS_HAVE_GC but tp_dealloc "
+                    f"'{dealloc_name}' doesn't call "
+                    f"PyObject_GC_UnTrack"
+                ),
+                "type_name": type_info["name"],
+            }
+        )
 
     # Check for heap type DECREF.
     if type_info.get("is_heap_type", False):
@@ -124,22 +141,27 @@ def _check_dealloc(type_info: dict, functions: list[dict],
             or ("type = Py_TYPE(" in body_text and "Py_DECREF(type)" in body_text)
         )
         if not has_type_decref:
-            findings.append({
-                "type": "heap_type_missing_type_decref",
-                "file": "",
-                "function": dealloc_name,
-                "line": dealloc_func["start_line"],
-                "confidence": "medium",
-                "detail": (f"Heap type tp_dealloc '{dealloc_name}' doesn't "
-                           f"Py_DECREF(Py_TYPE(self)) — type object leak"),
-                "type_name": type_info["name"],
-            })
+            findings.append(
+                {
+                    "type": "heap_type_missing_type_decref",
+                    "file": "",
+                    "function": dealloc_name,
+                    "line": dealloc_func["start_line"],
+                    "confidence": "medium",
+                    "detail": (
+                        f"Heap type tp_dealloc '{dealloc_name}' doesn't "
+                        f"Py_DECREF(Py_TYPE(self)) — type object leak"
+                    ),
+                    "type_name": type_info["name"],
+                }
+            )
 
     return findings
 
 
-def _check_dealloc_completeness(type_info: dict, functions: list[dict],
-                                 tree, source_bytes: bytes):
+def _check_dealloc_completeness(
+    type_info: dict, functions: list[dict], tree, source_bytes: bytes
+):
     """Check that dealloc XDECREF's all PyObject* struct members."""
     findings = []
     dealloc_name = type_info.get("dealloc_func")
@@ -148,7 +170,7 @@ def _check_dealloc_completeness(type_info: dict, functions: list[dict],
     if not dealloc_name or not struct_name:
         return findings
 
-    dealloc_name = re.sub(r'\([^)]*\)\s*', '', dealloc_name).strip()
+    dealloc_name = re.sub(r"\([^)]*\)\s*", "", dealloc_name).strip()
     dealloc_func = _find_func_by_name(functions, dealloc_name)
     if not dealloc_func:
         return findings
@@ -164,32 +186,35 @@ def _check_dealloc_completeness(type_info: dict, functions: list[dict],
     for member in pyobj_members:
         name = member["name"]
         patterns = [
-            rf'Py_XDECREF\s*\([^)]*->\s*{re.escape(name)}\s*\)',
-            rf'Py_DECREF\s*\([^)]*->\s*{re.escape(name)}\s*\)',
-            rf'Py_CLEAR\s*\([^)]*->\s*{re.escape(name)}\s*\)',
-            rf'Py_SETREF\s*\([^)]*->\s*{re.escape(name)}\s*,',
+            rf"Py_XDECREF\s*\([^)]*->\s*{re.escape(name)}\s*\)",
+            rf"Py_DECREF\s*\([^)]*->\s*{re.escape(name)}\s*\)",
+            rf"Py_CLEAR\s*\([^)]*->\s*{re.escape(name)}\s*\)",
+            rf"Py_SETREF\s*\([^)]*->\s*{re.escape(name)}\s*,",
         ]
         cleaned = any(re.search(p, dealloc_body) for p in patterns)
 
         if not cleaned:
-            findings.append({
-                "type": "dealloc_missing_xdecref",
-                "file": "",
-                "function": dealloc_name,
-                "line": dealloc_func["start_line"],
-                "confidence": "high",
-                "detail": (f"tp_dealloc '{dealloc_name}' doesn't XDECREF/CLEAR "
-                           f"PyObject* member '{name}' of {struct_name} — "
-                           f"reference leak per object destruction"),
-                "type_name": type_info["name"],
-                "missing_member": name,
-            })
+            findings.append(
+                {
+                    "type": "dealloc_missing_xdecref",
+                    "file": "",
+                    "function": dealloc_name,
+                    "line": dealloc_func["start_line"],
+                    "confidence": "high",
+                    "detail": (
+                        f"tp_dealloc '{dealloc_name}' doesn't XDECREF/CLEAR "
+                        f"PyObject* member '{name}' of {struct_name} — "
+                        f"reference leak per object destruction"
+                    ),
+                    "type_name": type_info["name"],
+                    "missing_member": name,
+                }
+            )
 
     return findings
 
 
-def _check_traverse(type_info: dict, functions: list[dict],
-                     tree, source_bytes: bytes):
+def _check_traverse(type_info: dict, functions: list[dict], tree, source_bytes: bytes):
     """Check tp_traverse visits all PyObject* members."""
     findings = []
     traverse_name = type_info.get("traverse_func")
@@ -198,7 +223,7 @@ def _check_traverse(type_info: dict, functions: list[dict],
     if not traverse_name or not struct_name:
         return findings
 
-    traverse_name = re.sub(r'\([^)]*\)\s*', '', traverse_name).strip()
+    traverse_name = re.sub(r"\([^)]*\)\s*", "", traverse_name).strip()
     traverse_func = _find_func_by_name(functions, traverse_name)
     if not traverse_func:
         return findings
@@ -213,33 +238,36 @@ def _check_traverse(type_info: dict, functions: list[dict],
     traverse_body = strip_comments(traverse_func["body"])
     for member in pyobj_members:
         # Check for Py_VISIT(self->member) or Py_VISIT(member).
-        pattern = rf'Py_VISIT\s*\([^)]*{re.escape(member["name"])}'
+        pattern = rf"Py_VISIT\s*\([^)]*{re.escape(member['name'])}"
         if not re.search(pattern, traverse_body):
-            findings.append({
-                "type": "traverse_missing_member",
-                "file": "",
-                "function": traverse_name,
-                "line": traverse_func["start_line"],
-                "confidence": "high",
-                "detail": (f"tp_traverse '{traverse_name}' doesn't visit "
-                           f"PyObject* member '{member['name']}' of "
-                           f"{struct_name}"),
-                "type_name": type_info["name"],
-                "missing_member": member["name"],
-            })
+            findings.append(
+                {
+                    "type": "traverse_missing_member",
+                    "file": "",
+                    "function": traverse_name,
+                    "line": traverse_func["start_line"],
+                    "confidence": "high",
+                    "detail": (
+                        f"tp_traverse '{traverse_name}' doesn't visit "
+                        f"PyObject* member '{member['name']}' of "
+                        f"{struct_name}"
+                    ),
+                    "type_name": type_info["name"],
+                    "missing_member": member["name"],
+                }
+            )
 
     return findings
 
 
-def _check_richcompare(type_info: dict, functions: list[dict],
-                        source_bytes: bytes):
+def _check_richcompare(type_info: dict, functions: list[dict], source_bytes: bytes):
     """Check tp_richcompare for Py_NotImplemented handling."""
     findings = []
     rc_name = type_info.get("richcompare_func")
     if not rc_name:
         return findings
 
-    rc_name = re.sub(r'\([^)]*\)\s*', '', rc_name).strip()
+    rc_name = re.sub(r"\([^)]*\)\s*", "", rc_name).strip()
     rc_func = _find_func_by_name(functions, rc_name)
     if not rc_func:
         return findings
@@ -253,19 +281,212 @@ def _check_richcompare(type_info: dict, functions: list[dict],
         return findings
 
     if "return Py_NotImplemented" in body:
-        if "Py_INCREF(Py_NotImplemented)" not in body and \
-           "Py_NewRef(Py_NotImplemented)" not in body:
-            findings.append({
-                "type": "richcompare_not_incref_notimplemented",
-                "file": "",
-                "function": rc_name,
-                "line": rc_func["start_line"],
-                "confidence": "high",
-                "detail": (f"tp_richcompare '{rc_name}' returns "
-                           f"Py_NotImplemented without Py_INCREF — "
-                           f"use Py_RETURN_NOTIMPLEMENTED"),
-                "type_name": type_info["name"],
-            })
+        if (
+            "Py_INCREF(Py_NotImplemented)" not in body
+            and "Py_NewRef(Py_NotImplemented)" not in body
+        ):
+            findings.append(
+                {
+                    "type": "richcompare_not_incref_notimplemented",
+                    "file": "",
+                    "function": rc_name,
+                    "line": rc_func["start_line"],
+                    "confidence": "high",
+                    "detail": (
+                        f"tp_richcompare '{rc_name}' returns "
+                        f"Py_NotImplemented without Py_INCREF — "
+                        f"use Py_RETURN_NOTIMPLEMENTED"
+                    ),
+                    "type_name": type_info["name"],
+                }
+            )
+
+    return findings
+
+
+def _check_init_reinit_safety(
+    type_info: dict, functions: list[dict], tree, source_bytes: bytes
+):
+    """Check if tp_init is safe to call multiple times.
+
+    Python allows calling __init__ multiple times on the same object.
+    If tp_init allocates resources without first cleaning up existing state,
+    the second call leaks or corrupts the first call's resources.
+    """
+    findings = []
+    init_name = type_info.get("init_func")
+    struct_name = type_info.get("struct_name")
+
+    if not init_name or not struct_name:
+        return findings
+
+    init_name = re.sub(r"\([^)]*\)\s*", "", init_name).strip()
+    init_func = _find_func_by_name(functions, init_name)
+    if not init_func:
+        return findings
+
+    body = strip_comments(init_func["body"])
+
+    # Find struct members that are pointers (PyObject* or raw pointers).
+    members = find_struct_members(tree, source_bytes, struct_name)
+    ptr_members = [m for m in members if m["is_pyobject"] or m["is_pointer"]]
+
+    if not ptr_members:
+        return findings
+
+    # Check for allocation/assignment patterns to pointer members.
+    # These indicate tp_init sets up resources that would leak on re-init.
+    alloc_patterns = [
+        r"PyMem_Malloc",
+        r"PyMem_Calloc",
+        r"PyMem_Realloc",
+        r"malloc\s*\(",
+        r"calloc\s*\(",
+        r"realloc\s*\(",
+        r"PyObject_New\b",
+        r"PyObject_GC_New\b",
+        r"PyList_New",
+        r"PyDict_New",
+        r"PyTuple_New",
+        r"PySet_New",
+        r"PyUnicode_FromString",
+        r"PyBytes_FromString",
+        r"Py_BuildValue",
+        r"PyObject_Call",
+    ]
+
+    has_alloc = any(re.search(p, body) for p in alloc_patterns)
+    if not has_alloc:
+        return findings
+
+    # Check if the function guards against re-init.
+    # Common patterns: checking if a member is already set, or raising
+    # an error if already initialized.
+    reinit_guard_patterns = [
+        r"already.{0,20}init",  # "already initialized" error
+        r"cannot.{0,20}re.?init",  # "cannot reinitialize"
+        r"PREVENT_INIT",  # macro-based guard (e.g., APSW)
+        r"init_was_called",  # flag-based guard
+        r"initialized\b",  # self->initialized flag check
+        r"if\s*\(\s*self->\w+\s*!=\s*NULL\s*\)",  # if (self->member != NULL)
+        r"if\s*\(\s*self->\w+\s*\)\s*\{[^}]*Py_CLEAR",  # if (self->m) { Py_CLEAR
+        r"if\s*\(\s*self->\w+\s*\)\s*\{[^}]*Py_XDECREF",
+        r"if\s*\(\s*self->\w+\s*\)\s*\{[^}]*Py_DECREF",
+        r"if\s*\(\s*self->\w+\s*\)\s*\{[^}]*free\s*\(",
+        r"if\s*\(\s*self->\w+\s*\)\s*\{[^}]*PyMem_Free",
+    ]
+
+    has_guard = any(re.search(p, body, re.IGNORECASE) for p in reinit_guard_patterns)
+    if has_guard:
+        return findings
+
+    # tp_init allocates resources without any re-init guard.
+    # Identify which members are assigned.
+    assigned_members = []
+    for m in ptr_members:
+        assign_pattern = rf"self\s*->\s*{re.escape(m['name'])}\s*="
+        if re.search(assign_pattern, body):
+            assigned_members.append(m["name"])
+
+    if not assigned_members:
+        return findings
+
+    findings.append(
+        {
+            "type": "init_not_reinit_safe",
+            "file": "",
+            "function": init_name,
+            "line": init_func["start_line"],
+            "confidence": "medium",
+            "detail": (
+                f"tp_init '{init_name}' allocates resources and assigns to "
+                f"member(s) {', '.join(assigned_members)} without checking "
+                f"for prior initialization. A second __init__() call on the "
+                f"same object will leak the first call's resources."
+            ),
+            "type_name": type_info["name"],
+        }
+    )
+
+    return findings
+
+
+def _check_new_without_init(
+    type_info: dict, functions: list[dict], tree, source_bytes: bytes
+):
+    """Check if tp_new initializes pointer members to safe defaults.
+
+    Python allows calling tp_new without tp_init (e.g., via
+    object.__new__(MyType)). If tp_new doesn't zero pointer members,
+    methods may dereference uninitialized pointers.
+    """
+    findings = []
+    new_name = type_info.get("new_func")
+    struct_name = type_info.get("struct_name")
+
+    if not new_name or not struct_name:
+        return findings
+
+    new_name = re.sub(r"\([^)]*\)\s*", "", new_name).strip()
+    new_func = _find_func_by_name(functions, new_name)
+    if not new_func:
+        return findings
+
+    body = strip_comments(new_func["body"])
+
+    # Find pointer members in the struct.
+    members = find_struct_members(tree, source_bytes, struct_name)
+    ptr_members = [m for m in members if m["is_pyobject"] or m["is_pointer"]]
+
+    if not ptr_members:
+        return findings
+
+    # Check if tp_new uses a zeroing allocator (tp_alloc, calloc, GC_New
+    # followed by memset). These zero all fields including pointers.
+    zeroing_patterns = [
+        r"tp_alloc\s*\(",  # tp_alloc zeros memory
+        r"PyType_GenericAlloc",  # zeros memory
+        r"calloc\s*\(",  # zeros memory
+        r"memset\s*\([^,]+,\s*0",  # explicit zero
+    ]
+
+    uses_zeroing_alloc = any(re.search(p, body) for p in zeroing_patterns)
+    if uses_zeroing_alloc:
+        return findings
+
+    # tp_new uses a non-zeroing allocator (malloc, PyObject_New, etc.)
+    # Check if each pointer member is explicitly initialized.
+    uninitialized = []
+    for m in ptr_members:
+        init_patterns = [
+            rf"self\s*->\s*{re.escape(m['name'])}\s*=",
+            rf"->\s*{re.escape(m['name'])}\s*=\s*NULL",
+            rf"->\s*{re.escape(m['name'])}\s*=\s*0",
+            rf"->\s*{re.escape(m['name'])}\s*=\s*Py_None",
+        ]
+        initialized = any(re.search(p, body) for p in init_patterns)
+        if not initialized:
+            uninitialized.append(m["name"])
+
+    if not uninitialized:
+        return findings
+
+    findings.append(
+        {
+            "type": "new_missing_member_init",
+            "file": "",
+            "function": new_name,
+            "line": new_func["start_line"],
+            "confidence": "medium",
+            "detail": (
+                f"tp_new '{new_name}' does not use a zeroing allocator and "
+                f"does not initialize pointer member(s) {', '.join(uninitialized)}. "
+                f"If __new__() is called without __init__(), methods may "
+                f"dereference uninitialized pointers."
+            ),
+            "type_name": type_info["name"],
+        }
+    )
 
     return findings
 
@@ -278,16 +499,20 @@ def _check_gc_flag(type_info: dict):
     has_gc = type_info.get("has_gc", False)
 
     if has_traverse and not has_gc:
-        findings.append({
-            "type": "missing_gc_flag",
-            "file": "",
-            "function": "(type definition)",
-            "line": type_info.get("line", 0),
-            "confidence": "medium",
-            "detail": (f"Type '{type_info['name']}' has tp_traverse but "
-                       f"doesn't have Py_TPFLAGS_HAVE_GC"),
-            "type_name": type_info["name"],
-        })
+        findings.append(
+            {
+                "type": "missing_gc_flag",
+                "file": "",
+                "function": "(type definition)",
+                "line": type_info.get("line", 0),
+                "confidence": "medium",
+                "detail": (
+                    f"Type '{type_info['name']}' has tp_traverse but "
+                    f"doesn't have Py_TPFLAGS_HAVE_GC"
+                ),
+                "type_name": type_info["name"],
+            }
+        )
 
     return findings
 
@@ -295,7 +520,6 @@ def _check_gc_flag(type_info: dict):
 def _check_type_spec_sentinel(tree, source_bytes: bytes):
     """Check PyType_Slot arrays end with {0, NULL}."""
     findings = []
-    source_text = source_bytes.decode("utf-8", errors="replace")
 
     slot_arrays = extract_struct_initializers(tree, source_bytes, "PyType_Slot")
     for arr in slot_arrays:
@@ -303,17 +527,21 @@ def _check_type_spec_sentinel(tree, source_bytes: bytes):
             continue
         init = arr["initializer_text"].strip()
         # Check if the last entry is {0, NULL} or {0, 0}.
-        if not re.search(r'\{\s*0\s*,\s*(?:NULL|0)\s*\}\s*\}?\s*$', init):
-            findings.append({
-                "type": "type_spec_missing_sentinel",
-                "file": "",
-                "function": "(type definition)",
-                "line": arr["start_line"],
-                "confidence": "high",
-                "detail": (f"PyType_Slot array '{arr['variable_name']}' "
-                           f"may not end with {{0, NULL}} sentinel"),
-                "array_name": arr["variable_name"],
-            })
+        if not re.search(r"\{\s*0\s*,\s*(?:NULL|0)\s*\}\s*\}?\s*$", init):
+            findings.append(
+                {
+                    "type": "type_spec_missing_sentinel",
+                    "file": "",
+                    "function": "(type definition)",
+                    "line": arr["start_line"],
+                    "confidence": "high",
+                    "detail": (
+                        f"PyType_Slot array '{arr['variable_name']}' "
+                        f"may not end with {{0, NULL}} sentinel"
+                    ),
+                    "array_name": arr["variable_name"],
+                }
+            )
 
     return findings
 
@@ -335,6 +563,8 @@ def _extract_type_infos(tree, source_bytes: bytes, functions: list[dict]) -> lis
             "dealloc_func": fields.get("tp_dealloc"),
             "traverse_func": fields.get("tp_traverse"),
             "richcompare_func": fields.get("tp_richcompare"),
+            "init_func": fields.get("tp_init"),
+            "new_func": fields.get("tp_new"),
             "struct_name": _get_struct_name_from_type(fields, source_text),
             "has_gc": "Py_TPFLAGS_HAVE_GC" in flags_text,
             "is_heap_type": "Py_TPFLAGS_HEAPTYPE" in flags_text,
@@ -353,7 +583,7 @@ def _extract_type_infos(tree, source_bytes: bytes, functions: list[dict]) -> lis
         if slots_name:
             # Look up the actual slots.
             slot_arrays = extract_struct_initializers(tree, source_bytes, "PyType_Slot")
-            dealloc = traverse = richcompare = None
+            dealloc = traverse = richcompare = init = new = None
             for sa in slot_arrays:
                 if sa["variable_name"] == slots_name:
                     slots = _parse_type_slots_array(sa["initializer_text"])
@@ -364,6 +594,10 @@ def _extract_type_infos(tree, source_bytes: bytes, functions: list[dict]) -> lis
                             traverse = slot_func
                         elif slot_type == "Py_tp_richcompare":
                             richcompare = slot_func
+                        elif slot_type == "Py_tp_init":
+                            init = slot_func
+                        elif slot_type == "Py_tp_new":
+                            new = slot_func
 
             info = {
                 "name": si["variable_name"],
@@ -371,6 +605,8 @@ def _extract_type_infos(tree, source_bytes: bytes, functions: list[dict]) -> lis
                 "dealloc_func": dealloc,
                 "traverse_func": traverse,
                 "richcompare_func": richcompare,
+                "init_func": init,
+                "new_func": new,
                 "struct_name": _get_struct_name_from_type(fields, source_text),
                 "has_gc": "Py_TPFLAGS_HAVE_GC" in flags_text,
                 "is_heap_type": True,  # PyType_Spec always creates heap types.
@@ -416,12 +652,18 @@ def analyze(target: str, *, max_files: int = 0) -> dict:
 
         for ti in type_infos:
             for checker_result in [
-                _check_dealloc(ti, functions, source_bytes,
-                               source_bytes.decode("utf-8", errors="replace")),
+                _check_dealloc(
+                    ti,
+                    functions,
+                    source_bytes,
+                    source_bytes.decode("utf-8", errors="replace"),
+                ),
                 _check_dealloc_completeness(ti, functions, tree, source_bytes),
                 _check_traverse(ti, functions, tree, source_bytes),
                 _check_richcompare(ti, functions, source_bytes),
                 _check_gc_flag(ti),
+                _check_init_reinit_safety(ti, functions, tree, source_bytes),
+                _check_new_without_init(ti, functions, tree, source_bytes),
             ]:
                 for f in checker_result:
                     f["file"] = rel

--- a/plugins/cext-review-toolkit/scripts/tree_sitter_utils.py
+++ b/plugins/cext-review-toolkit/scripts/tree_sitter_utils.py
@@ -18,10 +18,14 @@ try:
     import tree_sitter
     import tree_sitter_c
 except ImportError:
-    print(json.dumps({
-        "error": "tree-sitter not installed",
-        "install": "pip install tree-sitter tree-sitter-c",
-    }))
+    print(
+        json.dumps(
+            {
+                "error": "tree-sitter not installed",
+                "install": "pip install tree-sitter tree-sitter-c",
+            }
+        )
+    )
     sys.exit(1)
 
 # Initialize the C parser once at module level.
@@ -34,6 +38,7 @@ _cpp_parser: tree_sitter.Parser | None = None
 
 try:
     import tree_sitter_cpp
+
     _CPP_AVAILABLE = True
 except ImportError:
     pass
@@ -53,7 +58,9 @@ def _get_cpp_parser() -> tree_sitter.Parser:
     global _cpp_parser
     if _cpp_parser is None:
         if not _CPP_AVAILABLE:
-            raise ImportError("tree-sitter-cpp not installed: pip install tree-sitter-cpp")
+            raise ImportError(
+                "tree-sitter-cpp not installed: pip install tree-sitter-cpp"
+            )
         cpp_language = tree_sitter.Language(tree_sitter_cpp.language())
         _cpp_parser = tree_sitter.Parser(cpp_language)
     return _cpp_parser
@@ -90,7 +97,9 @@ def parse_bytes(source_bytes: bytes) -> tree_sitter.Tree:
 
 def get_node_text(node: tree_sitter.Node, source_bytes: bytes) -> str:
     """Get the source text for a tree-sitter node."""
-    return source_bytes[node.start_byte:node.end_byte].decode("utf-8", errors="replace")
+    return source_bytes[node.start_byte : node.end_byte].decode(
+        "utf-8", errors="replace"
+    )
 
 
 def walk_descendants(node: tree_sitter.Node, type_filter: str | None = None):
@@ -232,23 +241,26 @@ def extract_functions(tree: tree_sitter.Tree, source_bytes: bytes) -> list[dict]
         if body_text.startswith("{") and body_text.endswith("}"):
             body_text = body_text[1:-1]
 
-        functions.append({
-            "name": func_name,
-            "return_type": return_type,
-            "parameters": params_text,
-            "body": body_text,
-            "body_node": body_node,
-            "start_line": node.start_point[0] + 1,
-            "end_line": node.end_point[0] + 1,
-            "start_byte": node.start_byte,
-            "end_byte": node.end_byte,
-        })
+        functions.append(
+            {
+                "name": func_name,
+                "return_type": return_type,
+                "parameters": params_text,
+                "body": body_text,
+                "body_node": body_node,
+                "start_line": node.start_point[0] + 1,
+                "end_line": node.end_point[0] + 1,
+                "start_byte": node.start_byte,
+                "end_byte": node.end_byte,
+            }
+        )
 
     return functions
 
 
-def extract_struct_initializers(tree: tree_sitter.Tree, source_bytes: bytes,
-                                 type_name: str) -> list[dict]:
+def extract_struct_initializers(
+    tree: tree_sitter.Tree, source_bytes: bytes, type_name: str
+) -> list[dict]:
     """Find static struct initializers for a given type name.
 
     e.g., extract_struct_initializers(tree, source, "PyMethodDef") finds:
@@ -283,7 +295,10 @@ def extract_struct_initializers(tree: tree_sitter.Tree, source_bytes: bytes,
                 # Also check if it's "struct type_name"
                 found = False
                 for desc in walk_descendants(type_node):
-                    if desc.type == "type_identifier" and get_node_text(desc, source_bytes) == type_name:
+                    if (
+                        desc.type == "type_identifier"
+                        and get_node_text(desc, source_bytes) == type_name
+                    ):
                         found = True
                         break
                 if not found:
@@ -303,24 +318,30 @@ def extract_struct_initializers(tree: tree_sitter.Tree, source_bytes: bytes,
             if not var_name:
                 continue
 
-            is_array = "array_declarator" in get_node_text(declarator, source_bytes) or "[" in get_node_text(declarator, source_bytes)
+            is_array = "array_declarator" in get_node_text(
+                declarator, source_bytes
+            ) or "[" in get_node_text(declarator, source_bytes)
 
             init_text = get_node_text(value, source_bytes)
 
-            results.append({
-                "variable_name": var_name,
-                "type_name": type_name,
-                "is_array": is_array,
-                "initializer_text": init_text,
-                "initializer_node": value,
-                "start_line": node.start_point[0] + 1,
-                "end_line": node.end_point[0] + 1,
-            })
+            results.append(
+                {
+                    "variable_name": var_name,
+                    "type_name": type_name,
+                    "is_array": is_array,
+                    "initializer_text": init_text,
+                    "initializer_node": value,
+                    "start_line": node.start_point[0] + 1,
+                    "end_line": node.end_point[0] + 1,
+                }
+            )
 
     return results
 
 
-def extract_static_declarations(tree: tree_sitter.Tree, source_bytes: bytes) -> list[dict]:
+def extract_static_declarations(
+    tree: tree_sitter.Tree, source_bytes: bytes
+) -> list[dict]:
     """Find all file-scope static variable declarations.
 
     Returns list of dicts with keys:
@@ -344,7 +365,10 @@ def extract_static_declarations(tree: tree_sitter.Tree, source_bytes: bytes) -> 
         if not decl_text.lstrip().startswith("static"):
             has_static = False
             for child in node.children:
-                if child.type == "storage_class_specifier" and get_node_text(child, source_bytes) == "static":
+                if (
+                    child.type == "storage_class_specifier"
+                    and get_node_text(child, source_bytes) == "static"
+                ):
                     has_static = True
                     break
             if not has_static:
@@ -375,15 +399,19 @@ def extract_static_declarations(tree: tree_sitter.Tree, source_bytes: bytes) -> 
                 is_pointer = "*" in decl_part
                 is_pyobject = "PyObject" in decl_part
                 init_text = get_node_text(value, source_bytes) if value else None
-                results.append({
-                    "name": var_name,
-                    "type": decl_part.rsplit(var_name, 1)[0].strip() if var_name in decl_part else decl_part,
-                    "is_const": is_const,
-                    "is_pointer": is_pointer,
-                    "is_pyobject": is_pyobject,
-                    "initializer": init_text,
-                    "start_line": node.start_point[0] + 1,
-                })
+                results.append(
+                    {
+                        "name": var_name,
+                        "type": decl_part.rsplit(var_name, 1)[0].strip()
+                        if var_name in decl_part
+                        else decl_part,
+                        "is_const": is_const,
+                        "is_pointer": is_pointer,
+                        "is_pyobject": is_pyobject,
+                        "initializer": init_text,
+                        "start_line": node.start_point[0] + 1,
+                    }
+                )
             elif child.type in ("identifier", "pointer_declarator", "array_declarator"):
                 # Declaration without initializer.
                 var_name = get_declarator_name(child, source_bytes)
@@ -392,21 +420,26 @@ def extract_static_declarations(tree: tree_sitter.Tree, source_bytes: bytes) -> 
                 decl_part = decl_text.strip().rstrip(";").strip()
                 is_pointer = "*" in decl_part
                 is_pyobject = "PyObject" in decl_part
-                results.append({
-                    "name": var_name,
-                    "type": decl_part.rsplit(var_name, 1)[0].strip() if var_name in decl_part else decl_part,
-                    "is_const": is_const,
-                    "is_pointer": is_pointer,
-                    "is_pyobject": is_pyobject,
-                    "initializer": None,
-                    "start_line": node.start_point[0] + 1,
-                })
+                results.append(
+                    {
+                        "name": var_name,
+                        "type": decl_part.rsplit(var_name, 1)[0].strip()
+                        if var_name in decl_part
+                        else decl_part,
+                        "is_const": is_const,
+                        "is_pointer": is_pointer,
+                        "is_pyobject": is_pyobject,
+                        "initializer": None,
+                        "start_line": node.start_point[0] + 1,
+                    }
+                )
 
     return results
 
 
-def find_calls_in_scope(node: tree_sitter.Node, source_bytes: bytes,
-                         api_names: set[str] | None = None) -> list[dict]:
+def find_calls_in_scope(
+    node: tree_sitter.Node, source_bytes: bytes, api_names: set[str] | None = None
+) -> list[dict]:
     """Find all function calls within a given AST node (typically a function body).
 
     If api_names is provided, only return calls to those functions.
@@ -435,19 +468,22 @@ def find_calls_in_scope(node: tree_sitter.Node, source_bytes: bytes,
             if args_text.startswith("(") and args_text.endswith(")"):
                 args_text = args_text[1:-1].strip()
 
-        results.append({
-            "function_name": func_name,
-            "arguments_text": args_text,
-            "node": call_node,
-            "start_line": call_node.start_point[0] + 1,
-            "start_byte": call_node.start_byte,
-        })
+        results.append(
+            {
+                "function_name": func_name,
+                "arguments_text": args_text,
+                "node": call_node,
+                "start_line": call_node.start_point[0] + 1,
+                "start_byte": call_node.start_byte,
+            }
+        )
 
     return results
 
 
-def find_assignments_in_scope(node: tree_sitter.Node, source_bytes: bytes,
-                               var_name: str | None = None) -> list[dict]:
+def find_assignments_in_scope(
+    node: tree_sitter.Node, source_bytes: bytes, var_name: str | None = None
+) -> list[dict]:
     """Find variable assignments within a scope.
 
     If var_name is provided, only return assignments to that variable.
@@ -470,13 +506,15 @@ def find_assignments_in_scope(node: tree_sitter.Node, source_bytes: bytes,
         assigned_var = get_node_text(left, source_bytes)
         if var_name is not None and assigned_var != var_name:
             continue
-        results.append({
-            "variable": assigned_var,
-            "value_text": get_node_text(right, source_bytes),
-            "value_node": right,
-            "is_declaration": False,
-            "start_line": assign_node.start_point[0] + 1,
-        })
+        results.append(
+            {
+                "variable": assigned_var,
+                "value_text": get_node_text(right, source_bytes),
+                "value_node": right,
+                "is_declaration": False,
+                "start_line": assign_node.start_point[0] + 1,
+            }
+        )
 
     # Find declaration-initializations (init_declarator inside declarations).
     for decl_node in walk_descendants(node, "init_declarator"):
@@ -489,13 +527,15 @@ def find_assignments_in_scope(node: tree_sitter.Node, source_bytes: bytes,
             continue
         if var_name is not None and declared_var != var_name:
             continue
-        results.append({
-            "variable": declared_var,
-            "value_text": get_node_text(value, source_bytes),
-            "value_node": value,
-            "is_declaration": True,
-            "start_line": decl_node.start_point[0] + 1,
-        })
+        results.append(
+            {
+                "variable": declared_var,
+                "value_text": get_node_text(value, source_bytes),
+                "value_node": value,
+                "is_declaration": True,
+                "start_line": decl_node.start_point[0] + 1,
+            }
+        )
 
     return results
 
@@ -516,16 +556,19 @@ def find_return_statements(node: tree_sitter.Node, source_bytes: bytes) -> list[
             if child.type not in ("return", ";", "comment"):
                 value_text = get_node_text(child, source_bytes)
                 break
-        results.append({
-            "value_text": value_text,
-            "node": ret_node,
-            "start_line": ret_node.start_point[0] + 1,
-        })
+        results.append(
+            {
+                "value_text": value_text,
+                "node": ret_node,
+                "start_line": ret_node.start_point[0] + 1,
+            }
+        )
     return results
 
 
-def find_struct_members(tree: tree_sitter.Tree, source_bytes: bytes,
-                         struct_name: str) -> list[dict]:
+def find_struct_members(
+    tree: tree_sitter.Tree, source_bytes: bytes, struct_name: str
+) -> list[dict]:
     """Find members of a named struct definition.
 
     Returns list of dicts with keys:
@@ -553,7 +596,10 @@ def find_struct_members(tree: tree_sitter.Tree, source_bytes: bytes,
             if struct_name in type_def_text:
                 # Find the declarator of the typedef.
                 for child in parent.children:
-                    if child.type == "type_identifier" and get_node_text(child, source_bytes) == struct_name:
+                    if (
+                        child.type == "type_identifier"
+                        and get_node_text(child, source_bytes) == struct_name
+                    ):
                         is_match = True
                         break
 
@@ -568,8 +614,6 @@ def find_struct_members(tree: tree_sitter.Tree, source_bytes: bytes,
         for field in body.children:
             if field.type != "field_declaration":
                 continue
-            field_text = get_node_text(field, source_bytes).strip().rstrip(";").strip()
-
             # Find field name from the declarator.
             declarator = field.child_by_field_name("declarator")
             if not declarator:
@@ -588,14 +632,18 @@ def find_struct_members(tree: tree_sitter.Tree, source_bytes: bytes,
             if "*" in get_node_text(declarator, source_bytes):
                 field_type += " *"
 
+            is_pointer = "*" in field_type
             is_pyobject = "PyObject" in field_type
 
-            results.append({
-                "name": field_name,
-                "type": field_type,
-                "is_pyobject": is_pyobject,
-                "start_line": field.start_point[0] + 1,
-            })
+            results.append(
+                {
+                    "name": field_name,
+                    "type": field_type,
+                    "is_pyobject": is_pyobject,
+                    "is_pointer": is_pointer,
+                    "start_line": field.start_point[0] + 1,
+                }
+            )
 
     return results
 
@@ -604,7 +652,7 @@ def strip_comments(source: str) -> str:
     """Remove C comments (/* */ and //) from source text.
     Simpler than tree-sitter for cases where we just need clean text."""
     # Remove block comments.
-    source = re.sub(r'/\*.*?\*/', ' ', source, flags=re.DOTALL)
+    source = re.sub(r"/\*.*?\*/", " ", source, flags=re.DOTALL)
     # Remove line comments.
-    source = re.sub(r'//[^\n]*', ' ', source)
+    source = re.sub(r"//[^\n]*", " ", source)
     return source

--- a/tests/test_scan_type_slots.py
+++ b/tests/test_scan_type_slots.py
@@ -117,8 +117,9 @@ class TestScanTypeSlots(unittest.TestCase):
         """Detect traverse not visiting all PyObject* members."""
         with TempExtension({"buggy.c": BUGGY_TYPE}) as root:
             result = type_slots.analyze(str(root / "buggy.c"))
-            missing = [f for f in result["findings"]
-                       if f["type"] == "traverse_missing_member"]
+            missing = [
+                f for f in result["findings"] if f["type"] == "traverse_missing_member"
+            ]
             self.assertGreaterEqual(len(missing), 1)
             members = [f["missing_member"] for f in missing]
             self.assertIn("callback", members)
@@ -127,9 +128,17 @@ class TestScanTypeSlots(unittest.TestCase):
         """Correct type should have no dealloc or traverse findings."""
         with TempExtension({"good.c": CORRECT_TYPE}) as root:
             result = type_slots.analyze(str(root / "good.c"))
-            bad = [f for f in result["findings"]
-                   if f["type"] in ("dealloc_missing_tp_free", "dealloc_wrong_free",
-                                     "dealloc_missing_untrack", "traverse_missing_member")]
+            bad = [
+                f
+                for f in result["findings"]
+                if f["type"]
+                in (
+                    "dealloc_missing_tp_free",
+                    "dealloc_wrong_free",
+                    "dealloc_missing_untrack",
+                    "traverse_missing_member",
+                )
+            ]
             self.assertEqual(len(bad), 0)
 
     def test_richcompare_not_incref(self):
@@ -208,24 +217,33 @@ class TestTypeSpecSentinel(unittest.TestCase):
         """{0, 0} sentinel is accepted (no false positive)."""
         with TempExtension({"ext.c": TYPE_SPEC_SENTINEL_ZERO}) as root:
             result = type_slots.analyze(str(root / "ext.c"))
-            sentinel_findings = [f for f in result["findings"]
-                                 if f["type"] == "type_spec_missing_sentinel"]
+            sentinel_findings = [
+                f
+                for f in result["findings"]
+                if f["type"] == "type_spec_missing_sentinel"
+            ]
             self.assertEqual(len(sentinel_findings), 0)
 
     def test_sentinel_zero_null_accepted(self):
         """{0, NULL} sentinel is accepted."""
         with TempExtension({"ext.c": TYPE_SPEC_SENTINEL_NULL}) as root:
             result = type_slots.analyze(str(root / "ext.c"))
-            sentinel_findings = [f for f in result["findings"]
-                                 if f["type"] == "type_spec_missing_sentinel"]
+            sentinel_findings = [
+                f
+                for f in result["findings"]
+                if f["type"] == "type_spec_missing_sentinel"
+            ]
             self.assertEqual(len(sentinel_findings), 0)
 
     def test_missing_sentinel_detected(self):
         """Missing sentinel is flagged."""
         with TempExtension({"ext.c": TYPE_SPEC_MISSING_SENTINEL}) as root:
             result = type_slots.analyze(str(root / "ext.c"))
-            sentinel_findings = [f for f in result["findings"]
-                                 if f["type"] == "type_spec_missing_sentinel"]
+            sentinel_findings = [
+                f
+                for f in result["findings"]
+                if f["type"] == "type_spec_missing_sentinel"
+            ]
             self.assertGreater(len(sentinel_findings), 0)
 
 
@@ -291,8 +309,9 @@ class TestDeallocCompleteness(unittest.TestCase):
         """Detect PyObject* member not XDECREF'd in dealloc."""
         with TempExtension({"ext.c": DEALLOC_INCOMPLETE}) as root:
             result = type_slots.analyze(str(root / "ext.c"))
-            missing = [f for f in result["findings"]
-                       if f["type"] == "dealloc_missing_xdecref"]
+            missing = [
+                f for f in result["findings"] if f["type"] == "dealloc_missing_xdecref"
+            ]
             self.assertGreater(len(missing), 0)
             names = [f["missing_member"] for f in missing]
             self.assertIn("extra", names)
@@ -303,9 +322,158 @@ class TestDeallocCompleteness(unittest.TestCase):
         """Complete dealloc produces no dealloc_missing_xdecref findings."""
         with TempExtension({"ext.c": DEALLOC_COMPLETE}) as root:
             result = type_slots.analyze(str(root / "ext.c"))
-            missing = [f for f in result["findings"]
-                       if f["type"] == "dealloc_missing_xdecref"]
+            missing = [
+                f for f in result["findings"] if f["type"] == "dealloc_missing_xdecref"
+            ]
             self.assertEqual(len(missing), 0)
+
+
+INIT_REINIT_UNSAFE = """\
+#include <Python.h>
+
+typedef struct {
+    PyObject_HEAD
+    PyObject *data;
+    char *buffer;
+} UnsafeObj;
+
+static int
+UnsafeObj_init(UnsafeObj *self, PyObject *args, PyObject *kwds)
+{
+    /* BUG: allocates without checking if already initialized */
+    self->data = PyList_New(0);
+    self->buffer = PyMem_Malloc(1024);
+    return 0;
+}
+
+static PyTypeObject UnsafeObjType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "test.UnsafeObj",
+    .tp_basicsize = sizeof(UnsafeObj),
+    .tp_init = (initproc)UnsafeObj_init,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+};
+"""
+
+INIT_REINIT_SAFE = """\
+#include <Python.h>
+
+typedef struct {
+    PyObject_HEAD
+    PyObject *data;
+} SafeObj;
+
+static int
+SafeObj_init(SafeObj *self, PyObject *args, PyObject *kwds)
+{
+    /* Safe: cleans up before re-init */
+    if (self->data != NULL) {
+        Py_CLEAR(self->data);
+    }
+    self->data = PyList_New(0);
+    return 0;
+}
+
+static PyTypeObject SafeObjType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "test.SafeObj",
+    .tp_basicsize = sizeof(SafeObj),
+    .tp_init = (initproc)SafeObj_init,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+};
+"""
+
+NEW_WITHOUT_INIT_UNSAFE = """\
+#include <Python.h>
+
+typedef struct {
+    PyObject_HEAD
+    PyObject *data;
+    char *buffer;
+} BadNewObj;
+
+static PyObject *
+BadNewObj_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+{
+    /* BUG: uses PyObject_New (non-zeroing) without initializing members */
+    BadNewObj *self = (BadNewObj *)PyObject_New(BadNewObj, type);
+    /* data and buffer are uninitialized garbage */
+    return (PyObject *)self;
+}
+
+static PyTypeObject BadNewObjType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "test.BadNewObj",
+    .tp_basicsize = sizeof(BadNewObj),
+    .tp_new = BadNewObj_new,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+};
+"""
+
+NEW_WITH_INIT_SAFE = """\
+#include <Python.h>
+
+typedef struct {
+    PyObject_HEAD
+    PyObject *data;
+} GoodNewObj;
+
+static PyObject *
+GoodNewObj_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+{
+    /* Safe: uses tp_alloc which zeros memory */
+    GoodNewObj *self = (GoodNewObj *)type->tp_alloc(type, 0);
+    return (PyObject *)self;
+}
+
+static PyTypeObject GoodNewObjType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "test.GoodNewObj",
+    .tp_basicsize = sizeof(GoodNewObj),
+    .tp_new = GoodNewObj_new,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+};
+"""
+
+
+class TestInitReinitSafety(unittest.TestCase):
+    """Test tp_init re-init safety detection."""
+
+    def test_detects_unsafe_reinit(self):
+        """Detect tp_init that allocates without re-init guard."""
+        with TempExtension({"ext.c": INIT_REINIT_UNSAFE}) as root:
+            result = type_slots.analyze(str(root / "ext.c"))
+            types = [f["type"] for f in result["findings"]]
+            self.assertIn("init_not_reinit_safe", types)
+
+    def test_safe_reinit_no_finding(self):
+        """tp_init with re-init guard produces no finding."""
+        with TempExtension({"ext.c": INIT_REINIT_SAFE}) as root:
+            result = type_slots.analyze(str(root / "ext.c"))
+            reinit = [
+                f for f in result["findings"] if f["type"] == "init_not_reinit_safe"
+            ]
+            self.assertEqual(len(reinit), 0)
+
+
+class TestNewWithoutInit(unittest.TestCase):
+    """Test tp_new without tp_init safety detection."""
+
+    def test_detects_uninitialized_members(self):
+        """Detect tp_new with non-zeroing alloc and uninitialized members."""
+        with TempExtension({"ext.c": NEW_WITHOUT_INIT_UNSAFE}) as root:
+            result = type_slots.analyze(str(root / "ext.c"))
+            types = [f["type"] for f in result["findings"]]
+            self.assertIn("new_missing_member_init", types)
+
+    def test_zeroing_alloc_no_finding(self):
+        """tp_new using tp_alloc (zeroing) produces no finding."""
+        with TempExtension({"ext.c": NEW_WITH_INIT_SAFE}) as root:
+            result = type_slots.analyze(str(root / "ext.c"))
+            new_findings = [
+                f for f in result["findings"] if f["type"] == "new_missing_member_init"
+            ]
+            self.assertEqual(len(new_findings), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add two new checks to type-slot-checker based on APSW maintainer Roger Binns' feedback:
  - `init_not_reinit_safe`: detects `tp_init` that allocates resources without re-init guard (Python allows multiple `__init__()` calls)
  - `new_missing_member_init`: detects `tp_new` with non-zeroing allocator that doesn't initialize pointer members (Python allows `__new__()` without `__init__()`)
- Update agent prompt with new finding types, classification rules, and detailed tp_new/tp_init review guidance
- Add `is_pointer` field to `find_struct_members` in tree_sitter_utils.py
- Clean up pre-existing unused imports and variables in scan_type_slots.py

## Test plan
- [x] 4 new tests (2 true positive, 2 true negative) all pass
- [x] All 146 existing tests pass (no regressions)
- [x] Verified on real codebase: apsw correctly produces 0 false positives (PREVENT_INIT_MULTIPLE_CALLS macro recognized)
- [x] ruff format + ruff check pass with no errors

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)