### PR TITLE
feat: add new_and_init_partial_state triage check to type-slot-checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-03-29
+
+### Enhanced
+- `type-slot-checker` agent and `scan_type_slots.py`: added `new_and_init_partial_state` triage check. Flags types that define both `tp_new` and `tp_init`, which creates a partial-initialization window between `__new__` and `__init__`. Low confidence, used as a prioritization signal for deeper review of init safety issues. Skips types where `tp_new` is `PyType_GenericNew` (not a custom implementation). Based on APSW maintainer feedback.
+- `type-slot-checker` agent: added triage principle to tp_new/tp_init review section — types with no `tp_init` are inherently safe from re-init and partial-init issues.
+
 ## [0.1.4] - 2026-03-29
 
 ### Enhanced

--- a/plugins/cext-review-toolkit/.claude-plugin/plugin.json
+++ b/plugins/cext-review-toolkit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cext-review-toolkit",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "CPython C/C++ extension analysis agents: refcount auditing (with borrowed-ref-across-callback detection), error path analysis, NULL safety scanning, GIL discipline checking, module state validation, type slot correctness, stable ABI compliance, version compatibility scanning, PyErr_Clear auditing, resource lifecycle tracking, C/Python parity checking, complexity measurement, and git history analysis. Tree-sitter-powered C/C++ parsing with optional clang-tidy/cppcheck integration.",
   "author": {
     "name": "Danzin"

--- a/plugins/cext-review-toolkit/agents/type-slot-checker.md
+++ b/plugins/cext-review-toolkit/agents/type-slot-checker.md
@@ -42,6 +42,7 @@ Collect all findings and organize by type:
 | `type_spec_missing_sentinel` | CRITICAL | PyType_Slot array not terminated with {0, NULL} |
 | `init_not_reinit_safe` | HIGH | tp_init allocates resources without checking/cleaning prior state -- second __init__() call leaks |
 | `new_missing_member_init` | MEDIUM | tp_new uses non-zeroing allocator without initializing pointer members -- __new__() without __init__() leaves dangling pointers |
+| `new_and_init_partial_state` | LOW (triage) | Type defines both tp_new and tp_init, creating a partial-initialization window -- prioritize for deeper review |
 
 For each finding:
 1. Read the type's struct definition to understand all members.
@@ -88,7 +89,8 @@ For each type defined in the extension, perform a comprehensive slot audit:
    - If `Py_TPFLAGS_HAVE_GC` is set, objects must be allocated with `PyObject_GC_New` and tracked with `PyObject_GC_Track`.
    - If `Py_TPFLAGS_HAVE_GC` is NOT set, objects must NOT be allocated with GC functions.
 
-6. **tp_new / tp_init review** (critical for C extensions — Python allows calling patterns impossible in C++):
+6. **tp_new / tp_init review** (critical for C extensions — Python allows calling patterns impossible in C++).
+   **Triage principle:** Types with only `tp_new` (no `tp_init`) are safe by construction — all init is atomic. Types with only `tp_init` (inherited `tp_new`) start zeroed by `tp_alloc`. Types with BOTH have a partial-initialization window and should be reviewed first. A type that has no `tp_init` at all is inherently safe from re-init and partial-init issues regardless of its `tp_new` arguments.
    - Does `tp_new` allocate the object correctly (using `tp_alloc` which zeros memory)?
    - Does `tp_new` initialize ALL pointer members to NULL/safe defaults? Python allows `object.__new__(MyType)` without calling `__init__`, so methods may be called on objects where `tp_init` never ran. If `tp_new` doesn't zero pointers, methods that assume `tp_init` ran will dereference uninitialized garbage.
    - Does `tp_init` properly handle being called multiple times on the same object? Python allows `obj.__init__()` to be called again after construction. If `tp_init` allocates resources (malloc, PyObject_New, fopen, etc.) without first cleaning up existing state, the second call leaks the first call's resources. The fix is either: (a) reject re-init (`if (self->initialized) { PyErr_SetString(...); return -1; }`), or (b) clean up first (run destructor-like logic before re-initializing).

--- a/plugins/cext-review-toolkit/scripts/scan_type_slots.py
+++ b/plugins/cext-review-toolkit/scripts/scan_type_slots.py
@@ -491,6 +491,61 @@ def _check_new_without_init(
     return findings
 
 
+def _check_new_and_init_partial_state(type_info: dict):
+    """Flag types that define both tp_new and tp_init.
+
+    Types with both have a partial-initialization window between __new__
+    returning and __init__ completing. This is a triage signal — not a bug
+    by itself, but it means the type is susceptible to __new__-without-__init__
+    issues and should be reviewed for the more specific init_not_reinit_safe
+    and new_missing_member_init patterns.
+
+    Types with only tp_new are safe (all init is atomic). Types with only
+    tp_init (inherited tp_new from base) start zeroed by tp_alloc.
+    """
+    findings = []
+    new_name = type_info.get("new_func")
+    init_name = type_info.get("init_func")
+
+    if not new_name or not init_name:
+        return findings
+
+    # Strip casts.
+    new_name_clean = re.sub(r"\([^)]*\)\s*", "", new_name).strip()
+    init_name_clean = re.sub(r"\([^)]*\)\s*", "", init_name).strip()
+
+    # Skip if tp_new is the generic default (not a custom implementation).
+    generic_new_names = {
+        "PyType_GenericNew",
+        "PyBaseObject_Type.tp_new",
+        "object_new",
+    }
+    if new_name_clean in generic_new_names:
+        return findings
+
+    findings.append(
+        {
+            "type": "new_and_init_partial_state",
+            "file": "",
+            "function": f"{new_name_clean} / {init_name_clean}",
+            "line": type_info.get("line", 0),
+            "confidence": "low",
+            "detail": (
+                f"Type '{type_info['name']}' defines both tp_new "
+                f"('{new_name_clean}') and tp_init ('{init_name_clean}'). "
+                f"This creates a partial-initialization window between "
+                f"__new__ and __init__ — methods called before __init__ "
+                f"(or on objects where __init__ was never called) may "
+                f"encounter missing state. Review for init_not_reinit_safe "
+                f"and new_missing_member_init issues."
+            ),
+            "type_name": type_info["name"],
+        }
+    )
+
+    return findings
+
+
 def _check_gc_flag(type_info: dict):
     """Check if type has traverse but no GC flag."""
     findings = []
@@ -664,6 +719,7 @@ def analyze(target: str, *, max_files: int = 0) -> dict:
                 _check_gc_flag(ti),
                 _check_init_reinit_safety(ti, functions, tree, source_bytes),
                 _check_new_without_init(ti, functions, tree, source_bytes),
+                _check_new_and_init_partial_state(ti),
             ]:
                 for f in checker_result:
                     f["file"] = rel

--- a/tests/test_scan_type_slots.py
+++ b/tests/test_scan_type_slots.py
@@ -476,5 +476,123 @@ class TestNewWithoutInit(unittest.TestCase):
             self.assertEqual(len(new_findings), 0)
 
 
+TYPE_WITH_NEW_AND_INIT = """\
+#include <Python.h>
+
+typedef struct {
+    PyObject_HEAD
+    PyObject *data;
+} BothObj;
+
+static PyObject *
+BothObj_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+{
+    BothObj *self = (BothObj *)type->tp_alloc(type, 0);
+    return (PyObject *)self;
+}
+
+static int
+BothObj_init(BothObj *self, PyObject *args, PyObject *kwds)
+{
+    self->data = PyList_New(0);
+    return 0;
+}
+
+static PyTypeObject BothObjType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "test.BothObj",
+    .tp_basicsize = sizeof(BothObj),
+    .tp_new = BothObj_new,
+    .tp_init = (initproc)BothObj_init,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+};
+"""
+
+TYPE_WITH_ONLY_NEW = """\
+#include <Python.h>
+
+typedef struct {
+    PyObject_HEAD
+    PyObject *data;
+} OnlyNewObj;
+
+static PyObject *
+OnlyNewObj_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+{
+    OnlyNewObj *self = (OnlyNewObj *)type->tp_alloc(type, 0);
+    if (self != NULL) {
+        self->data = PyList_New(0);
+    }
+    return (PyObject *)self;
+}
+
+static PyTypeObject OnlyNewObjType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "test.OnlyNewObj",
+    .tp_basicsize = sizeof(OnlyNewObj),
+    .tp_new = OnlyNewObj_new,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+};
+"""
+
+TYPE_WITH_GENERIC_NEW_AND_INIT = """\
+#include <Python.h>
+
+typedef struct {
+    PyObject_HEAD
+    PyObject *data;
+} GenericNewObj;
+
+static int
+GenericNewObj_init(GenericNewObj *self, PyObject *args, PyObject *kwds)
+{
+    self->data = PyList_New(0);
+    return 0;
+}
+
+static PyTypeObject GenericNewObjType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "test.GenericNewObj",
+    .tp_basicsize = sizeof(GenericNewObj),
+    .tp_new = PyType_GenericNew,
+    .tp_init = (initproc)GenericNewObj_init,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+};
+"""
+
+
+class TestNewAndInitPartialState(unittest.TestCase):
+    """Test new_and_init_partial_state triage check."""
+
+    def test_detects_both_new_and_init(self):
+        """Flag type with both custom tp_new and tp_init."""
+        with TempExtension({"ext.c": TYPE_WITH_NEW_AND_INIT}) as root:
+            result = type_slots.analyze(str(root / "ext.c"))
+            types = [f["type"] for f in result["findings"]]
+            self.assertIn("new_and_init_partial_state", types)
+
+    def test_only_new_no_finding(self):
+        """Type with only tp_new (no tp_init) produces no finding."""
+        with TempExtension({"ext.c": TYPE_WITH_ONLY_NEW}) as root:
+            result = type_slots.analyze(str(root / "ext.c"))
+            partial = [
+                f
+                for f in result["findings"]
+                if f["type"] == "new_and_init_partial_state"
+            ]
+            self.assertEqual(len(partial), 0)
+
+    def test_generic_new_with_init_no_finding(self):
+        """Type with PyType_GenericNew + tp_init produces no finding."""
+        with TempExtension({"ext.c": TYPE_WITH_GENERIC_NEW_AND_INIT}) as root:
+            result = type_slots.analyze(str(root / "ext.c"))
+            partial = [
+                f
+                for f in result["findings"]
+                if f["type"] == "new_and_init_partial_state"
+            ]
+            self.assertEqual(len(partial), 0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add `new_and_init_partial_state` check: flags types defining both `tp_new` and `tp_init` as having a partial-initialization window (low-confidence triage signal for deeper review)
- Skips types where `tp_new` is `PyType_GenericNew` (not a custom implementation)
- Add triage principle to agent prompt: types with no `tp_init` are inherently safe from re-init and partial-init issues
- Bump plugin version to 0.1.5

## Test plan
- [x] 3 new tests: true positive (both new+init), true negative (only new), true negative (GenericNew+init)
- [x] All 149 tests pass (no regressions)
- [x] ruff format + ruff check pass

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)