### PR TITLE
feat: Phase 2-3 — new scanners, global numbering, multi-run support

### DIFF
--- a/plugins/cext-review-toolkit/agents/version-compat-scanner.md
+++ b/plugins/cext-review-toolkit/agents/version-compat-scanner.md
@@ -206,3 +206,5 @@ After all findings, include a summary:
 7. **Report at most 20 findings.** Prioritize FIX over CONSIDER over POLICY. Include counts for categories with many findings.
 
 8. **Verify deprecation claims against documentation.** Do not infer deprecation from nearby functions or from the existence of a replacement API. Only flag an API as deprecated if the CPython documentation explicitly states it, or if it appears in `data/deprecated_apis.json`. For example, `PySys_GetObject` is NOT deprecated even though `PySys_GetAttr` was added in 3.13 — they coexist.
+
+9. **Suggest code removal, not just replacement.** Check `data/deprecated_apis.json` `code_removal_opportunities` section. When the extension's minimum Python version supports a consolidating API (e.g., `PyModule_AddType` on 3.10+), report how many lines of boilerplate could be deleted. Maintainers prefer removing code over adding code. Example: "19 type registrations using `PyType_FromSpec` + `PyType_Ready` + `Py_INCREF` + `PyModule_AddObject` could each be replaced by a single `PyModule_AddType` call, removing ~100 lines."

--- a/plugins/cext-review-toolkit/commands/explore.md
+++ b/plugins/cext-review-toolkit/commands/explore.md
@@ -43,6 +43,8 @@ Parse arguments into three categories:
 - `summary` → summary tier only (faster)
 - `parallel` → run agents concurrently where possible
 - `--max-parallel N` → cap concurrent agents per group (default: 2)
+- `--runs N` → run agents N times (default: 1). Run 2+ are independent naive passes. Findings are deduplicated across runs. If run 2 finds 0 new findings, report "high confidence — converged on first pass."
+- `--informed-reruns` → when used with `--runs 3`, run 3 agents receive a summary of runs 1-2 findings with the instruction: "These bugs were already found. Look at ADJACENT code, unexplored error paths, and patterns similar to these confirmed bugs that the prior runs might have missed." This targets the informed-rerun technique that found 33% more bugs on simplejson.
 
 ## Execution Workflow
 
@@ -210,33 +212,55 @@ G = No FIX findings | Y = 1-3 FIX findings | R = 4+ FIX findings
 
 ## Findings by Priority
 
-### Must Fix (FIX)
-[Crash risks, memory corruption, reference counting bugs]
+**Use global non-restarting numbering**: number ALL findings sequentially across all sections. FIX findings first (1-N), then CONSIDER (N+1-M), then POLICY (M+1-P). Use these same numbers in the action plan. This makes it easy to reference "Finding 37" in issue trackers and emails.
 
-### Should Consider (CONSIDER)
-[Improvement opportunities, modernization, compatibility]
+### Must Fix (FIX) — N
+
+| # | Finding | File:Line | Agents |
+|---|---------|-----------|--------|
+| 1 | [Description] | [file:line] | [which agents found it] |
+
+### Should Consider (CONSIDER) — M
+
+| # | Finding | File:Line |
+|---|---------|-----------|
+| N+1 | [Description] | [file:line] |
 
 ### Tensions
 [Where agents disagree or trade-offs exist]
 
-### Policy Decisions (POLICY)
-[Team-level decisions: init style, ABI, version support]
+### Policy Decisions (POLICY) — P
+
+| # | Finding |
+|---|---------|
+| M+1 | [Description] |
 
 ## Strengths
 [What the extension does well -- correct patterns, good error handling, etc.]
 
+## Code Removal Opportunities
+
+Check `<plugin_root>/data/deprecated_apis.json` `code_removal_opportunities` section. For each entry, search the codebase for the `replaces_pattern` and report how many lines could be removed. Example:
+
+- **PyModule_AddType** (3.10+): replaces `PyType_FromSpec` + `PyType_Ready` + `Py_INCREF` + `PyModule_AddObject` chain. Est. 4-8 lines saved per type.
+- **PyImport_ImportModuleAttrString** (3.14+): replaces `PyImport_ImportModule` + `PyObject_GetAttrString` + `Py_DECREF(module)`. Est. 5-8 lines per import+getattr.
+
+Only include entries where the extension's minimum Python version supports the replacement API.
+
 ## Recommended Action Plan
 
+Reference findings by their global number:
+
 ### Immediate (FIX items)
-1. [Highest-impact safety fix]
-2. [Next]
+1. [Fix Finding N — description]
+2. [Fix Finding M — description]
 
 ### Short-term (CONSIDER items)
-1. [Quality improvement]
-2. [Modernization step]
+1. [Finding N+1 — description]
+2. [Finding N+2 — description]
 
 ### Longer-term (POLICY)
-1. [Strategic decisions]
+1. [Finding M+1 — description]
 ```
 
 ## How Extension Discovery Context Flows

--- a/plugins/cext-review-toolkit/scripts/scan_format_strings.py
+++ b/plugins/cext-review-toolkit/scripts/scan_format_strings.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Validate PyArg_ParseTuple / Py_BuildValue format strings.
+
+Checks that the number of format codes in the format string matches
+the number of variadic arguments passed to the call.
+
+Also covers PyErr_Format, PyUnicode_FromFormat (printf-style formats).
+
+Usage:
+    python scan_format_strings.py [path] [--max-files N]
+"""
+
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from tree_sitter_utils import (
+    parse_bytes_for_file,
+    extract_functions,
+    find_calls_in_scope,
+    get_node_text,
+)
+from scan_common import find_project_root, discover_c_files, parse_common_args
+
+
+# PyArg_ParseTuple format codes that consume one C argument.
+# See https://docs.python.org/3/c-api/arg.html
+_PYARG_FORMAT_CODES = set("bBhHiIlLnOfdsUySzZpP")
+
+# Py_BuildValue format codes that consume one C argument.
+_BUILD_FORMAT_CODES = set("bBhHiIlLnOfdsUNSzZ")
+
+# Printf-style format codes (for PyErr_Format, PyUnicode_FromFormat).
+_PRINTF_FORMAT_RE = re.compile(r"%(?:\d+\$)?[-+ #0]*\d*(?:\.\d+)?(?:l{0,2}|z|j|t|h{0,2})?[diouxXeEfFgGaAcspnR%UV]")
+
+# APIs using PyArg_ParseTuple-style format strings.
+_PYARG_APIS = {
+    "PyArg_ParseTuple",
+    "PyArg_ParseTupleAndKeywords",
+    "PyArg_VaParse",
+    "PyArg_VaParseTupleAndKeywords",
+    "Py_BuildValue",
+}
+
+# APIs using printf-style format strings.
+_PRINTF_APIS = {
+    "PyErr_Format",
+    "PyErr_FormatUnraisable",
+    "PyUnicode_FromFormat",
+    "PyUnicode_FromFormatV",
+    "PyErr_SetString",  # Not printf-style, but often confused
+}
+
+
+def _count_pyarg_format_args(fmt: str) -> int | None:
+    """Count the number of C arguments expected by a PyArg format string.
+
+    Returns None if the format string can't be parsed (e.g., contains
+    unknown format codes or complex nested structures).
+    """
+    count = 0
+    i = 0
+    while i < len(fmt):
+        ch = fmt[i]
+        if ch in _PYARG_FORMAT_CODES:
+            count += 1
+        elif ch == "(":
+            # Tuple: each code inside consumes an arg
+            pass
+        elif ch == ")":
+            pass
+        elif ch == "|":
+            # Optional arguments separator — doesn't consume an arg
+            pass
+        elif ch == "$":
+            # Keyword-only separator
+            pass
+        elif ch == ":":
+            # Function name follows — stop counting
+            break
+        elif ch == ";":
+            # Error message follows — stop counting
+            break
+        elif ch == "#":
+            # Followed by a Py_ssize_t for string length
+            count += 1
+        elif ch == "!":
+            # Used after 'O' for type checking (O! consumes 2 args)
+            count += 1
+        elif ch == "&":
+            # Used after 'O' for converter (O& consumes 2 args)
+            count += 1
+        elif ch == "e":
+            # Encoded string: 'es', 'et', 'es#', 'et#' consume 2-3 args
+            if i + 1 < len(fmt) and fmt[i + 1] in "st":
+                count += 2  # encoding + buffer
+                i += 1
+                if i + 1 < len(fmt) and fmt[i + 1] == "#":
+                    count += 1  # + length
+                    i += 1
+            else:
+                return None  # Unknown 'e' usage
+        elif ch in " \t\n":
+            pass  # Whitespace is allowed
+        elif ch == "*":
+            # y*, s*, z*, w* — buffer protocol, consumes 1 Py_buffer
+            pass  # The preceding format code already counted
+        elif ch == "{":
+            # Not a standard format code
+            return None
+        else:
+            # Unknown format code
+            return None
+        i += 1
+    return count
+
+
+def _count_printf_format_args(fmt: str) -> int:
+    """Count the number of arguments expected by a printf-style format string."""
+    count = 0
+    for m in _PRINTF_FORMAT_RE.finditer(fmt):
+        spec = m.group()
+        if spec == "%%":
+            continue  # Literal %
+        count += 1
+    return count
+
+
+def _extract_format_string(call_text: str, api_name: str) -> str | None:
+    """Extract the format string literal from a call expression text.
+
+    Returns the format string content (without quotes), or None if
+    the format string is not a literal.
+    """
+    # Find the argument that is a string literal.
+    # For PyArg_ParseTuple: 2nd arg (after self/args)
+    # For Py_BuildValue: 1st arg
+    # For PyErr_Format: 2nd arg (after exception type)
+    # For PyUnicode_FromFormat: 1st arg
+
+    # Simple approach: find all string literals in the call text
+    strings = re.findall(r'"((?:[^"\\]|\\.)*)"', call_text)
+    if not strings:
+        return None
+
+    if api_name in ("Py_BuildValue", "PyUnicode_FromFormat", "PyUnicode_FromFormatV"):
+        # First string literal is the format
+        return strings[0] if strings else None
+    elif api_name in ("PyArg_ParseTuple", "PyArg_VaParse"):
+        # Second arg is format (first is args tuple)
+        return strings[0] if strings else None
+    elif api_name == "PyArg_ParseTupleAndKeywords":
+        # Third arg is format (first is args, second is kwargs)
+        return strings[0] if strings else None
+    elif api_name in ("PyErr_Format", "PyErr_FormatUnraisable"):
+        # Second arg is format (first is exception type)
+        return strings[0] if strings else None
+    else:
+        return strings[0] if strings else None
+
+
+def _count_variadic_args(arguments_text: str, api_name: str) -> int | None:
+    """Count the variadic arguments after the format string.
+
+    Returns None if we can't determine the count (e.g., macro-wrapped).
+    """
+    # Split by commas at top level (not inside parens/brackets)
+    parts = []
+    depth = 0
+    current = []
+    for ch in arguments_text:
+        if ch in "(<[":
+            depth += 1
+            current.append(ch)
+        elif ch in ")>]":
+            depth -= 1
+            current.append(ch)
+        elif ch == "," and depth == 0:
+            parts.append("".join(current).strip())
+            current = []
+        else:
+            current.append(ch)
+    if current:
+        parts.append("".join(current).strip())
+
+    # Determine where the format string is and count args after it
+    if api_name in ("Py_BuildValue",):
+        # Py_BuildValue(format, ...) — format is arg 0
+        return len(parts) - 1 if len(parts) > 0 else None
+    elif api_name in ("PyArg_ParseTuple", "PyArg_VaParse"):
+        # PyArg_ParseTuple(args, format, ...) — format is arg 1
+        return len(parts) - 2 if len(parts) > 1 else None
+    elif api_name == "PyArg_ParseTupleAndKeywords":
+        # PyArg_ParseTupleAndKeywords(args, kwargs, format, kwlist, ...)
+        # format is arg 2, kwlist is arg 3, variadics start at arg 4
+        return len(parts) - 4 if len(parts) > 3 else None
+    elif api_name in ("PyErr_Format", "PyErr_FormatUnraisable"):
+        # PyErr_Format(exc, format, ...) — format is arg 1
+        return len(parts) - 2 if len(parts) > 1 else None
+    elif api_name in ("PyUnicode_FromFormat",):
+        # PyUnicode_FromFormat(format, ...) — format is arg 0
+        return len(parts) - 1 if len(parts) > 0 else None
+    return None
+
+
+def _check_format_strings(func, source_bytes):
+    """Check format string argument counts in a function."""
+    findings = []
+    body = func["body_node"]
+
+    all_apis = _PYARG_APIS | _PRINTF_APIS
+    calls = find_calls_in_scope(body, source_bytes, api_names=all_apis)
+
+    for call in calls:
+        api_name = call["function_name"]
+        args_text = call["arguments_text"]
+        full_text = get_node_text(call["node"], source_bytes)
+
+        fmt_str = _extract_format_string(full_text, api_name)
+        if fmt_str is None:
+            continue  # Not a literal format string
+
+        if api_name in _PYARG_APIS:
+            expected = _count_pyarg_format_args(fmt_str)
+            if expected is None:
+                continue  # Couldn't parse format
+        elif api_name in _PRINTF_APIS:
+            expected = _count_printf_format_args(fmt_str)
+        else:
+            continue
+
+        actual = _count_variadic_args(args_text, api_name)
+        if actual is None:
+            continue
+
+        if actual != expected:
+            findings.append({
+                "type": "format_string_mismatch",
+                "file": "",
+                "function": func["name"],
+                "line": call["start_line"],
+                "confidence": "high",
+                "detail": (
+                    f"{api_name}() format string expects {expected} "
+                    f"variadic arg(s) but {actual} provided"
+                ),
+                "api_call": api_name,
+                "format_string": fmt_str,
+                "expected_args": expected,
+                "actual_args": actual,
+            })
+
+    return findings
+
+
+def analyze(target: str, *, max_files: int = 0) -> dict:
+    """Scan C files for format string mismatches."""
+    target_path = Path(target).resolve()
+    project_root = find_project_root(target_path)
+    scan_root = target_path if target_path.is_dir() else target_path.parent
+
+    findings = []
+    total_functions = 0
+    files_analyzed = 0
+    skipped = []
+
+    for filepath in discover_c_files(scan_root, max_files=max_files):
+        try:
+            source_bytes = filepath.read_bytes()
+        except OSError as e:
+            skipped.append({"file": str(filepath), "reason": str(e)})
+            continue
+
+        tree = parse_bytes_for_file(source_bytes, filepath)
+        functions = extract_functions(tree, source_bytes)
+        if not functions:
+            continue
+
+        files_analyzed += 1
+        try:
+            rel = str(filepath.relative_to(project_root))
+        except ValueError:
+            rel = str(filepath)
+
+        for func in functions:
+            total_functions += 1
+            for f in _check_format_strings(func, source_bytes):
+                f["file"] = rel
+                findings.append(f)
+
+    by_type = defaultdict(int)
+    by_confidence = defaultdict(int)
+    for f in findings:
+        by_type[f["type"]] += 1
+        by_confidence[f["confidence"]] += 1
+
+    return {
+        "project_root": str(project_root),
+        "scan_root": str(scan_root),
+        "functions_analyzed": total_functions,
+        "files_analyzed": files_analyzed,
+        "findings": findings,
+        "summary": {
+            "total_findings": len(findings),
+            "by_type": dict(by_type),
+            "by_confidence": dict(by_confidence),
+        },
+        "skipped_files": skipped,
+    }
+
+
+def main():
+    target, max_files = parse_common_args(sys.argv[1:])
+    result = analyze(target, max_files=max_files)
+    json.dump(result, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/cext-review-toolkit/scripts/scan_gil_usage.py
+++ b/plugins/cext-review-toolkit/scripts/scan_gil_usage.py
@@ -328,6 +328,63 @@ def _check_free_threading(tree, source_bytes):
     return findings
 
 
+def _check_object_invalidation(func, source_bytes):
+    """Check for self->member use after GIL release/reacquire.
+
+    When the GIL is released, another thread could call close() or
+    mutate the object's state. After reacquiring the GIL, code that
+    uses self->member without re-validation is operating on potentially
+    stale/invalid state.
+    """
+    findings = []
+    body_text = func["body"]
+
+    begin_re = re.compile(r"Py_BEGIN_ALLOW_THREADS")
+    end_re = re.compile(r"Py_END_ALLOW_THREADS")
+
+    begins = list(begin_re.finditer(body_text))
+    ends = list(end_re.finditer(body_text))
+
+    for b in begins:
+        matching_end = None
+        for e in ends:
+            if e.start() > b.end():
+                matching_end = e
+                break
+        if not matching_end:
+            continue
+
+        # Get the code AFTER Py_END_ALLOW_THREADS (post-reacquire region)
+        post_region = body_text[matching_end.end():]
+
+        # Find self->member accesses in the post-reacquire region
+        member_accesses = re.finditer(
+            r"\bself\s*->\s*(\w+)", post_region
+        )
+        for m in member_accesses:
+            member = m.group(1)
+            # Check if this member was also accessed BEFORE the GIL release
+            pre_region = body_text[:b.start()]
+            if re.search(rf"\bself\s*->\s*{re.escape(member)}\b", pre_region):
+                line_offset = body_text[:matching_end.end() + m.start()].count("\n")
+                findings.append({
+                    "type": "object_invalidation_across_gil_release",
+                    "file": "",
+                    "function": func["name"],
+                    "line": func["start_line"] + line_offset,
+                    "confidence": "medium",
+                    "detail": (
+                        f"self->{member} used after GIL reacquire "
+                        f"(another thread could have invalidated it "
+                        f"during Py_BEGIN/END_ALLOW_THREADS)"
+                    ),
+                    "member": member,
+                })
+                break  # One finding per GIL-release region
+
+    return findings
+
+
 def analyze(target: str, *, max_files: int = 0) -> dict:
     """Scan C files for GIL discipline issues."""
     target_path = Path(target).resolve()
@@ -362,7 +419,8 @@ def analyze(target: str, *, max_files: int = 0) -> dict:
             for checker in (_check_mismatched_allow_threads,
                             _check_api_without_gil,
                             _check_blocking_with_gil,
-                            _check_mismatched_gilstate):
+                            _check_mismatched_gilstate,
+                            _check_object_invalidation):
                 for f in checker(func, source_bytes):
                     f["file"] = rel
                     findings.append(f)

--- a/plugins/cext-review-toolkit/scripts/scan_type_slots.py
+++ b/plugins/cext-review-toolkit/scripts/scan_type_slots.py
@@ -643,6 +643,110 @@ def _check_type_spec_sentinel(tree, source_bytes: bytes):
     return findings
 
 
+# Expected parameter counts for each METH_* flag combination.
+_METH_PARAM_COUNTS = {
+    "METH_NOARGS": 2,       # (self, Py_UNUSED(ignored)) — CPython passes NULL
+    "METH_O": 2,            # (self, arg)
+    "METH_VARARGS": 2,      # (self, args)
+    "METH_KEYWORDS": 3,     # (self, args, kwargs) — with METH_VARARGS
+    "METH_FASTCALL": 3,     # (self, args, nargs)
+    "METH_FASTCALL_KW": 4,  # (self, args, nargs, kwnames)
+    "METH_METHOD": 4,       # (defining_class, self, args, nargs) — min, +1 for kwnames
+}
+
+
+def _check_method_signatures(tree, source_bytes: bytes, functions: list[dict]):
+    """Check that PyMethodDef function signatures match METH_* flags."""
+    findings = []
+
+    method_tables = extract_struct_initializers(tree, source_bytes, "PyMethodDef")
+    func_by_name = {f["name"]: f for f in functions}
+
+    for table in method_tables:
+        if not table["is_array"]:
+            continue
+
+        init_text = strip_comments(table["initializer_text"])
+
+        # Parse entries: {name, func, flags, doc}
+        # Each entry is between { and }
+        entries = re.findall(
+            r"\{\s*\"([^\"]+)\"\s*,\s*"         # name string
+            r"(?:\([^)]*\)\s*)?(\w+)\s*,\s*"    # func (possibly cast)
+            r"([^,}]+?)\s*,"                     # flags
+            r"[^}]*\}",                          # doc + close
+            init_text,
+        )
+
+        for method_name, func_name, flags_str in entries:
+            flags_str = flags_str.strip()
+
+            # Determine expected param count from flags
+            has_keywords = "METH_KEYWORDS" in flags_str
+            has_fastcall = "METH_FASTCALL" in flags_str
+            has_method = "METH_METHOD" in flags_str
+
+            if has_method:
+                expected = 5 if has_keywords else 4
+            elif has_fastcall:
+                expected = 4 if has_keywords else 3
+            elif has_keywords:
+                expected = 3  # METH_VARARGS | METH_KEYWORDS
+            elif "METH_O" in flags_str:
+                expected = 2
+            elif "METH_NOARGS" in flags_str:
+                expected = 2
+            elif "METH_VARARGS" in flags_str:
+                expected = 2
+            else:
+                continue  # Unknown flags
+
+            # Look up the function
+            func = func_by_name.get(func_name)
+            if func is None:
+                continue
+
+            # Count parameters
+            params_str = func["parameters"]
+            if not params_str or params_str.strip() == "void":
+                actual = 0
+            else:
+                # Split by comma, but be careful with function pointer params
+                depth = 0
+                count = 1
+                for ch in params_str:
+                    if ch in "(<":
+                        depth += 1
+                    elif ch in ")>":
+                        depth -= 1
+                    elif ch == "," and depth == 0:
+                        count += 1
+                actual = count
+
+            if actual != expected:
+                flags_desc = flags_str.replace("|", " | ").strip()
+                findings.append(
+                    {
+                        "type": "method_signature_mismatch",
+                        "file": "",
+                        "function": func_name,
+                        "line": func["start_line"],
+                        "confidence": "high",
+                        "detail": (
+                            f"Method '{method_name}' registered with {flags_desc} "
+                            f"(expects {expected} params) but {func_name}() "
+                            f"has {actual} params"
+                        ),
+                        "method_name": method_name,
+                        "flags": flags_str,
+                        "expected_params": expected,
+                        "actual_params": actual,
+                    }
+                )
+
+    return findings
+
+
 def _extract_type_infos(tree, source_bytes: bytes, functions: list[dict]) -> list[dict]:
     """Extract type definition information from PyTypeObject and PyType_Spec."""
     type_infos = []
@@ -770,6 +874,9 @@ def analyze(target: str, *, max_files: int = 0) -> dict:
 
         # File-level checks.
         for f in _check_type_spec_sentinel(tree, source_bytes):
+            f["file"] = rel
+            findings.append(f)
+        for f in _check_method_signatures(tree, source_bytes, functions):
             f["file"] = rel
             findings.append(f)
 

--- a/tests/test_scan_format_strings.py
+++ b/tests/test_scan_format_strings.py
@@ -1,0 +1,111 @@
+"""Tests for scan_format_strings.py — format string validation."""
+
+import unittest
+from helpers import import_script, TempExtension
+
+fmt = import_script("scan_format_strings")
+
+
+MISMATCH_PYARG = """\
+#include <Python.h>
+
+static PyObject *
+wrong_count(PyObject *self, PyObject *args)
+{
+    int a;
+    double b;
+    /* Format expects 2 args (i, d) but only 1 address provided */
+    if (!PyArg_ParseTuple(args, "id", &a))
+        return NULL;
+    Py_RETURN_NONE;
+}
+"""
+
+CORRECT_PYARG = """\
+#include <Python.h>
+
+static PyObject *
+correct_count(PyObject *self, PyObject *args)
+{
+    int a;
+    double b;
+    if (!PyArg_ParseTuple(args, "id", &a, &b))
+        return NULL;
+    Py_RETURN_NONE;
+}
+"""
+
+BUILD_VALUE_MISMATCH = """\
+#include <Python.h>
+
+static PyObject *
+wrong_build(PyObject *self, PyObject *args)
+{
+    /* Format expects 3 args (i, s, f) but only 2 provided */
+    return Py_BuildValue("isf", 42, "hello");
+}
+"""
+
+PRINTF_FORMAT = """\
+#include <Python.h>
+
+static PyObject *
+wrong_format(PyObject *self, PyObject *args)
+{
+    /* Format expects 2 args (%s, %d) but 3 provided */
+    PyErr_Format(PyExc_TypeError, "got %s and %d", "hello", 42, 99);
+    return NULL;
+}
+"""
+
+
+class TestScanFormatStrings(unittest.TestCase):
+    """Test format string mismatch detection."""
+
+    def test_detects_pyarg_mismatch(self):
+        """Detect wrong arg count in PyArg_ParseTuple."""
+        with TempExtension({"ext.c": MISMATCH_PYARG}) as root:
+            result = fmt.analyze(str(root / "ext.c"))
+            types = [f["type"] for f in result["findings"]]
+            self.assertIn("format_string_mismatch", types)
+            finding = [f for f in result["findings"]
+                       if f["type"] == "format_string_mismatch"][0]
+            self.assertEqual(finding["api_call"], "PyArg_ParseTuple")
+            self.assertEqual(finding["expected_args"], 2)
+            self.assertEqual(finding["actual_args"], 1)
+
+    def test_correct_pyarg_no_finding(self):
+        """Correct PyArg_ParseTuple should not produce finding."""
+        with TempExtension({"ext.c": CORRECT_PYARG}) as root:
+            result = fmt.analyze(str(root / "ext.c"))
+            mismatches = [f for f in result["findings"]
+                          if f["type"] == "format_string_mismatch"]
+            self.assertEqual(len(mismatches), 0)
+
+    def test_detects_build_value_mismatch(self):
+        """Detect wrong arg count in Py_BuildValue."""
+        with TempExtension({"ext.c": BUILD_VALUE_MISMATCH}) as root:
+            result = fmt.analyze(str(root / "ext.c"))
+            types = [f["type"] for f in result["findings"]]
+            self.assertIn("format_string_mismatch", types)
+
+    def test_detects_printf_format_mismatch(self):
+        """Detect wrong arg count in PyErr_Format."""
+        with TempExtension({"ext.c": PRINTF_FORMAT}) as root:
+            result = fmt.analyze(str(root / "ext.c"))
+            types = [f["type"] for f in result["findings"]]
+            self.assertIn("format_string_mismatch", types)
+
+    def test_output_envelope(self):
+        """Output has correct structure."""
+        with TempExtension({"ext.c": CORRECT_PYARG}) as root:
+            result = fmt.analyze(str(root / "ext.c"))
+            self.assertIn("project_root", result)
+            self.assertIn("scan_root", result)
+            self.assertIn("functions_analyzed", result)
+            self.assertIn("findings", result)
+            self.assertIn("summary", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scan_type_slots.py
+++ b/tests/test_scan_type_slots.py
@@ -594,5 +594,52 @@ class TestNewAndInitPartialState(unittest.TestCase):
             self.assertEqual(len(partial), 0)
 
 
+METHOD_SIG_MISMATCH = """\
+#include <Python.h>
+
+static PyObject *
+wrong_noargs(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    Py_RETURN_NONE;
+}
+
+static PyObject *
+correct_noargs(PyObject *self, PyObject *Py_UNUSED(ignored))
+{
+    Py_RETURN_NONE;
+}
+
+static PyMethodDef methods[] = {
+    {"wrong", (PyCFunction)wrong_noargs, METH_NOARGS, NULL},
+    {"correct", (PyCFunction)correct_noargs, METH_NOARGS, NULL},
+    {NULL, NULL, 0, NULL}
+};
+"""
+
+
+class TestMethodSignatures(unittest.TestCase):
+    """Test PyMethodDef signature validation against METH_* flags."""
+
+    def test_detects_noargs_mismatch(self):
+        """Detect METH_NOARGS function with 3 params (should be 2)."""
+        with TempExtension({"ext.c": METHOD_SIG_MISMATCH}) as root:
+            result = type_slots.analyze(str(root / "ext.c"))
+            mismatches = [f for f in result["findings"]
+                          if f["type"] == "method_signature_mismatch"]
+            self.assertEqual(len(mismatches), 1)
+            self.assertEqual(mismatches[0]["method_name"], "wrong")
+            self.assertEqual(mismatches[0]["expected_params"], 2)
+            self.assertEqual(mismatches[0]["actual_params"], 3)
+
+    def test_correct_noargs_no_finding(self):
+        """Correct METH_NOARGS function with 2 params should not produce finding."""
+        with TempExtension({"ext.c": METHOD_SIG_MISMATCH}) as root:
+            result = type_slots.analyze(str(root / "ext.c"))
+            mismatches = [f for f in result["findings"]
+                          if f["type"] == "method_signature_mismatch"
+                          and f["method_name"] == "correct"]
+            self.assertEqual(len(mismatches), 0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Implements 6 enhancement issues (Phase 2-3 of the implementation plan):

- **#29** — PyMethodDef signature validation: new `_check_method_signatures()` in `scan_type_slots.py` validates param count against METH_* flags
- **#32** — Object invalidation across GIL release: new `_check_object_invalidation()` in `scan_gil_usage.py` finds self->member use after GIL reacquire
- **#27** — Format string validation: new `scan_format_strings.py` validates PyArg_ParseTuple, Py_BuildValue, PyErr_Format, PyUnicode_FromFormat arg counts
- **#33** — Global non-restarting numbering: updated explore.md synthesis template (FIX 1-N, CONSIDER N+1-M, POLICY M+1-P)
- **#31** — Multi-run support: added `--runs N` and `--informed-reruns` options to explore command
- **#34** — Code removal suggestions: added guideline 9 to version-compat agent prompt

## Test plan

- [x] All 156 tests pass (`python -m unittest discover tests -v`)
- [x] Format string scanner tested with PyArg, BuildValue, and printf-style mismatches
- [x] Method signature checker tested with METH_NOARGS mismatch (3 params instead of 2)

Closes #29, closes #32, closes #27, closes #33, closes #31.
(#34 agent/command parts — data part was in PR #38)

🤖 Generated with [Claude Code](https://claude.com/claude-code)