### PR TITLE
Sync cross-toolkit improvements: shared helpers, history perf, silent-failure hardening

### DIFF
--- a/plugins/cext-review-toolkit/agents/c-complexity-analyzer.md
+++ b/plugins/cext-review-toolkit/agents/c-complexity-analyzer.md
@@ -192,3 +192,10 @@ If external tools are available:
 7. **Consider the test implications.** High cyclomatic complexity means many paths to test. If the function also lacks tests, the risk is compounded.
 
 8. **Report at most 15 hotspot findings.** If more exist, focus on the top 10 by score and the top 5 by safety correlation. Include the total count.
+
+## Running the script
+
+- Call the script with a Bash timeout of **300000 ms** (5 min). The default 120s kills on large repos.
+- Use a **unique temp filename** for the JSON output, e.g. `/tmp/c-complexity-analyzer_<scope>_$$.json` -- the `$$` PID suffix prevents collisions when multiple agents run concurrently.
+- Forward `--max-files N` and (where supported) `--workers N` from the caller.
+- If the script **times out or errors, do NOT retry it.** Fall back to Grep/Read for the same question. Long-running runs should use `run_in_background`.

--- a/plugins/cext-review-toolkit/agents/error-path-analyzer.md
+++ b/plugins/cext-review-toolkit/agents/error-path-analyzer.md
@@ -159,3 +159,18 @@ If external tools are available:
 7. **Recognize sentinel/vtable error propagation patterns.** Some extensions use sentinel objects (e.g., an `xt_error` struct with error-returning methods) to handle errors via vtable dispatch. When the error-setting function is called immediately before the sentinel method with no intervening Python API calls, the exception is still pending — this is not a "NULL without exception" bug. Only flag if there are intervening calls that could clear the exception.
 
 8. **Recognize defensive visitor/callback patterns.** When a function passes potentially-NULL values to a callback/visitor, check if all known visitors handle NULL defensively (e.g., checking their arguments, recording errors in a "sticky error" field in the callback arg struct). If the protocol is designed for defensive callbacks, classify as CONSIDER rather than FIX.
+
+## Running the script
+
+- Call the script with a Bash timeout of **300000 ms** (5 min). The default 120s kills on large repos.
+- Use a **unique temp filename** for the JSON output, e.g. `/tmp/error-path-analyzer_<scope>_$$.json` -- the `$$` PID suffix prevents collisions when multiple agents run concurrently.
+- Forward `--max-files N` and (where supported) `--workers N` from the caller.
+- If the script **times out or errors, do NOT retry it.** Fall back to Grep/Read for the same question. Long-running runs should use `run_in_background`.
+
+## Confidence
+
+- **HIGH** -- structurally identical to a known-bad pattern, or exact signature match; >=90% likelihood of being a true positive.
+- **MEDIUM** -- similar with differences that require human verification; 70-89%.
+- **LOW** -- superficially similar; requires code-context reading; 50-69%.
+
+Findings below LOW are not reported.

--- a/plugins/cext-review-toolkit/agents/gil-discipline-checker.md
+++ b/plugins/cext-review-toolkit/agents/gil-discipline-checker.md
@@ -164,3 +164,18 @@ If external tools are available:
 6. **Check for `#ifdef Py_GIL_DISABLED` guards.** Modern extensions may have separate code paths for free-threaded Python. Verify that both paths are correct.
 
 7. **Report at most 20 findings.** Prioritize correctness issues (FIX) over performance (CONSIDER) over policy (POLICY).
+
+## Running the script
+
+- Call the script with a Bash timeout of **300000 ms** (5 min). The default 120s kills on large repos.
+- Use a **unique temp filename** for the JSON output, e.g. `/tmp/gil-discipline-checker_<scope>_$$.json` -- the `$$` PID suffix prevents collisions when multiple agents run concurrently.
+- Forward `--max-files N` and (where supported) `--workers N` from the caller.
+- If the script **times out or errors, do NOT retry it.** Fall back to Grep/Read for the same question. Long-running runs should use `run_in_background`.
+
+## Confidence
+
+- **HIGH** -- structurally identical to a known-bad pattern, or exact signature match; >=90% likelihood of being a true positive.
+- **MEDIUM** -- similar with differences that require human verification; 70-89%.
+- **LOW** -- superficially similar; requires code-context reading; 50-69%.
+
+Findings below LOW are not reported.

--- a/plugins/cext-review-toolkit/agents/git-history-analyzer.md
+++ b/plugins/cext-review-toolkit/agents/git-history-analyzer.md
@@ -38,7 +38,38 @@ The script produces structured output with:
 
 Review the output and focus on `recent_fixes` first (highest value for finding similar bugs), then `file_churn` and `function_churn` for the risk matrix.
 
-### Phase 2: Similar Bug Detection (Highest Value)
+**Effort allocation**: 60% similar-bug detection (Phase 3), 15% fix-completeness review (Phase 2), 25% churn-risk matrix + contextual observations (Phase 4+).
+
+### Phase 2: Fix Completeness Review
+
+Before searching for similar bugs elsewhere, check whether each fix is itself complete. C extensions use the same `goto`-cleanup patterns as CPython, so the same completeness gaps apply. For each recent fix commit (cap at 15):
+
+1. **Read the fix diff and commit message**: Understand what was reported broken and what the fix changes.
+
+2. **Check all code paths in the fixed function**:
+   - Does the fix cover all error branches? Many extension functions have multiple `goto error` / `goto done` / `goto cleanup` labels — a fix might patch one branch but miss another.
+   - Does the fix cover all `#ifdef` platform variants? A fix to the Unix code path may leave the `#ifdef MS_WINDOWS` (or `#ifdef Py_GIL_DISABLED`) path unfixed, or vice versa.
+   - Does the fix cover all affected variables? A refcount leak fix for `var_a` may leave `var_b` with the same leak pattern in the same function.
+
+3. **Check root cause vs. symptom**: Did the fix address the root cause, or did it patch the symptom? For example, adding a NULL check after an API call that shouldn't have returned NULL in the first place — was the real bug in the caller or the callee?
+
+4. **Check for regression risk**: Did the fix change a condition or code path that other callers depend on? Could the fix break something else?
+
+5. **Classify each fix**:
+   - **FIX** if the fix is demonstrably incomplete (missed cleanup label, missed platform variant, missed variable)
+   - **CONSIDER** if the fix might be incomplete but requires deeper analysis to confirm
+   - **ACCEPTABLE** if the fix appears complete and correct
+
+Output format for incomplete fixes:
+
+```
+#### [FIX] Incomplete fix in commit [SHA] — [title]
+**What was fixed**: [description]
+**What was missed**: [specific missed cleanup label, variable, or platform variant]
+**Evidence**: [line numbers, code snippet showing the unfixed path]
+```
+
+### Phase 3: Similar Bug Detection (Highest Value)
 
 This is the most valuable capability of this agent. For each recent fix commit:
 
@@ -72,7 +103,7 @@ This is the most valuable capability of this agent. For each recent fix commit:
 
 5. **Cap at 10 similar-bug findings**: If there are more, prioritize by confidence and severity. Note the total count.
 
-### Phase 3: Churn-Risk Matrix
+### Phase 4: Churn-Risk Matrix
 
 Combine churn data with quality signals:
 
@@ -93,7 +124,7 @@ Combine churn data with quality signals:
 
 4. **Cap at 10 risk matrix entries**: Focus on the highest-risk files/functions.
 
-### Phase 4: Contextual Observations
+### Phase 5: Contextual Observations
 
 Note any interesting patterns:
 
@@ -161,7 +192,7 @@ After all findings:
 
 ## Important Guidelines
 
-1. **Similar bug detection is the primary value.** Invest 70% of the analysis effort here. The churn matrix is secondary context.
+1. **Similar bug detection is the primary value.** Invest 60% of effort here, 15% on fix completeness (Phase 2), and 25% on churn matrix + contextual observations. The churn matrix is secondary context.
 
 2. **Function-level churn uses Tree-sitter for C files.** The script identifies function boundaries using Tree-sitter parsing, so function-level churn is reliable. Python files use AST parsing.
 
@@ -178,3 +209,18 @@ After all findings:
 8. **Do not overemphasize co-change coupling.** While interesting, co-change clusters are less actionable than similar bugs. Mention them in observations but do not dedicate detailed findings to them.
 
 9. **Do not emphasize new feature review.** This agent is for temporal analysis, not feature review. Feature commits are noted for context (fix-to-feature ratio) but not analyzed in detail.
+
+## Running the script
+
+- Call the script with a Bash timeout of **300000 ms** (5 min). The default 120s kills on large repos.
+- Use a **unique temp filename** for the JSON output, e.g. `/tmp/git-history-analyzer_<scope>_$$.json` -- the `$$` PID suffix prevents collisions when multiple agents run concurrently.
+- Forward `--max-files N` and (where supported) `--workers N` from the caller.
+- If the script **times out or errors, do NOT retry it.** Fall back to Grep/Read for the same question. Long-running runs should use `run_in_background`.
+
+## Confidence
+
+- **HIGH** -- structurally identical to a known-bad pattern, or exact signature match; >=90% likelihood of being a true positive.
+- **MEDIUM** -- similar with differences that require human verification; 70-89%.
+- **LOW** -- superficially similar; requires code-context reading; 50-69%.
+
+Findings below LOW are not reported.

--- a/plugins/cext-review-toolkit/agents/module-state-checker.md
+++ b/plugins/cext-review-toolkit/agents/module-state-checker.md
@@ -167,3 +167,18 @@ After all findings, include a Migration Assessment section:
 5. **Heap type dealloc must decref the type.** When using `PyType_FromSpec` for heap types, the `tp_dealloc` function must include `Py_DECREF(Py_TYPE(self))` at the end. Missing this causes the type object to leak.
 
 6. **Report at most 20 findings.** The migration assessment section is separate and always included regardless of finding count.
+
+## Running the script
+
+- Call the script with a Bash timeout of **300000 ms** (5 min). The default 120s kills on large repos.
+- Use a **unique temp filename** for the JSON output, e.g. `/tmp/module-state-checker_<scope>_$$.json` -- the `$$` PID suffix prevents collisions when multiple agents run concurrently.
+- Forward `--max-files N` and (where supported) `--workers N` from the caller.
+- If the script **times out or errors, do NOT retry it.** Fall back to Grep/Read for the same question. Long-running runs should use `run_in_background`.
+
+## Confidence
+
+- **HIGH** -- structurally identical to a known-bad pattern, or exact signature match; >=90% likelihood of being a true positive.
+- **MEDIUM** -- similar with differences that require human verification; 70-89%.
+- **LOW** -- superficially similar; requires code-context reading; 50-69%.
+
+Findings below LOW are not reported.

--- a/plugins/cext-review-toolkit/agents/null-safety-scanner.md
+++ b/plugins/cext-review-toolkit/agents/null-safety-scanner.md
@@ -148,3 +148,18 @@ If external tools are available, enhance your analysis:
 5. **Be precise about which dereference causes the crash.** Do not just say "line 100 might crash." Say "line 100 dereferences `result` which is the return value of `PyObject_CallObject` at line 98, which returns NULL if the call raises an exception."
 
 6. **Report at most 20 findings.** Prioritize by severity and reachability. Mention the total count if more were found.
+
+## Running the script
+
+- Call the script with a Bash timeout of **300000 ms** (5 min). The default 120s kills on large repos.
+- Use a **unique temp filename** for the JSON output, e.g. `/tmp/null-safety-scanner_<scope>_$$.json` -- the `$$` PID suffix prevents collisions when multiple agents run concurrently.
+- Forward `--max-files N` and (where supported) `--workers N` from the caller.
+- If the script **times out or errors, do NOT retry it.** Fall back to Grep/Read for the same question. Long-running runs should use `run_in_background`.
+
+## Confidence
+
+- **HIGH** -- structurally identical to a known-bad pattern, or exact signature match; >=90% likelihood of being a true positive.
+- **MEDIUM** -- similar with differences that require human verification; 70-89%.
+- **LOW** -- superficially similar; requires code-context reading; 50-69%.
+
+Findings below LOW are not reported.

--- a/plugins/cext-review-toolkit/agents/pyerr-clear-auditor.md
+++ b/plugins/cext-review-toolkit/agents/pyerr-clear-auditor.md
@@ -162,3 +162,18 @@ Common fix patterns:
 5. **Cross-reference with error-path-analyzer.** If that agent also flagged exception handling issues, merge the findings. The error-path-analyzer catches exception clobbering; this agent catches exception swallowing.
 
 6. **Recognize intentional fallback patterns.** When `PyErr_Clear()` follows a failed `PyImport_ImportModule` or `PyObject_GetAttrString` and the code continues with a fallback/default value (e.g., optional import of `_testinternalcapi`), classify as CONSIDER (intentional fallback) rather than FIX. Note that guarding with `PyErr_ExceptionMatches(PyExc_ImportError)` would be more precise but is not required for this pattern.
+
+## Running the script
+
+- Call the script with a Bash timeout of **300000 ms** (5 min). The default 120s kills on large repos.
+- Use a **unique temp filename** for the JSON output, e.g. `/tmp/pyerr-clear-auditor_<scope>_$$.json` -- the `$$` PID suffix prevents collisions when multiple agents run concurrently.
+- Forward `--max-files N` and (where supported) `--workers N` from the caller.
+- If the script **times out or errors, do NOT retry it.** Fall back to Grep/Read for the same question. Long-running runs should use `run_in_background`.
+
+## Confidence
+
+- **HIGH** -- structurally identical to a known-bad pattern, or exact signature match; >=90% likelihood of being a true positive.
+- **MEDIUM** -- similar with differences that require human verification; 70-89%.
+- **LOW** -- superficially similar; requires code-context reading; 50-69%.
+
+Findings below LOW are not reported.

--- a/plugins/cext-review-toolkit/agents/refcount-auditor.md
+++ b/plugins/cext-review-toolkit/agents/refcount-auditor.md
@@ -119,3 +119,18 @@ For each confirmed or likely finding, produce a structured entry:
 8. **Report at most 20 findings.** If there are more, prioritize by severity and confidence. Mention the total count and note that lower-priority findings were omitted.
 
 9. **Borrowed refs from immutable containers are safe if the container is alive.** When a borrowed reference comes from `PyTuple_GetItem`/`PyTuple_GET_ITEM`, the tuple holds a strong reference to the item. Since tuples are immutable, no Python call can remove items from them. As long as the function holds a strong reference to the tuple (e.g., it's a function parameter or a local with Py_INCREF'd ownership), the borrowed ref is safe across intervening Python calls. Do NOT flag these as `borrowed_ref_across_call`. This does NOT apply to mutable containers like lists or dicts.
+
+## Running the script
+
+- Call the script with a Bash timeout of **300000 ms** (5 min). The default 120s kills on large repos.
+- Use a **unique temp filename** for the JSON output, e.g. `/tmp/refcount-auditor_<scope>_$$.json` -- the `$$` PID suffix prevents collisions when multiple agents run concurrently.
+- Forward `--max-files N` and (where supported) `--workers N` from the caller.
+- If the script **times out or errors, do NOT retry it.** Fall back to Grep/Read for the same question. Long-running runs should use `run_in_background`.
+
+## Confidence
+
+- **HIGH** -- structurally identical to a known-bad pattern, or exact signature match; >=90% likelihood of being a true positive.
+- **MEDIUM** -- similar with differences that require human verification; 70-89%.
+- **LOW** -- superficially similar; requires code-context reading; 50-69%.
+
+Findings below LOW are not reported.

--- a/plugins/cext-review-toolkit/agents/resource-lifecycle-checker.md
+++ b/plugins/cext-review-toolkit/agents/resource-lifecycle-checker.md
@@ -146,3 +146,18 @@ If other agents have run, cross-reference:
 5. **Cap output.** At most 15 confirmed findings. Note totals if more exist.
 
 6. **Custom resource pairs.** The scanner uses `data/resource_pairs.json` for allocation/free mappings. If the extension uses a library with its own resource lifecycle (not already in the file), note what pairs should be added for a more thorough scan.
+
+## Running the script
+
+- Call the script with a Bash timeout of **300000 ms** (5 min). The default 120s kills on large repos.
+- Use a **unique temp filename** for the JSON output, e.g. `/tmp/resource-lifecycle-checker_<scope>_$$.json` -- the `$$` PID suffix prevents collisions when multiple agents run concurrently.
+- Forward `--max-files N` and (where supported) `--workers N` from the caller.
+- If the script **times out or errors, do NOT retry it.** Fall back to Grep/Read for the same question. Long-running runs should use `run_in_background`.
+
+## Confidence
+
+- **HIGH** -- structurally identical to a known-bad pattern, or exact signature match; >=90% likelihood of being a true positive.
+- **MEDIUM** -- similar with differences that require human verification; 70-89%.
+- **LOW** -- superficially similar; requires code-context reading; 50-69%.
+
+Findings below LOW are not reported.

--- a/plugins/cext-review-toolkit/agents/stable-abi-checker.md
+++ b/plugins/cext-review-toolkit/agents/stable-abi-checker.md
@@ -156,3 +156,11 @@ After all findings, include a summary:
 6. **The limited API version sets the floor.** If `Py_LIMITED_API = 0x03090000`, the extension cannot use ANY API added in 3.10+. Verify every API call against the version table.
 
 7. **Report at most 20 individual findings.** For large codebases with many violations, group by category and report counts, with detailed findings for the most significant ones.
+
+## Confidence
+
+- **HIGH** -- structurally identical to a known-bad pattern, or exact signature match; >=90% likelihood of being a true positive.
+- **MEDIUM** -- similar with differences that require human verification; 70-89%.
+- **LOW** -- superficially similar; requires code-context reading; 50-69%.
+
+Findings below LOW are not reported.

--- a/plugins/cext-review-toolkit/agents/type-slot-checker.md
+++ b/plugins/cext-review-toolkit/agents/type-slot-checker.md
@@ -194,3 +194,18 @@ For each confirmed or likely finding, produce a structured entry:
 5. **Static types and heap types have different lifecycles.** Static types live forever (one per process). Heap types are reference-counted and can be destroyed. Mixing the patterns (e.g., decrementing a static type) is a bug.
 
 6. **Report at most 20 findings across all types.** If the extension defines many types, summarize the common issues and provide detailed findings for the most critical ones.
+
+## Running the script
+
+- Call the script with a Bash timeout of **300000 ms** (5 min). The default 120s kills on large repos.
+- Use a **unique temp filename** for the JSON output, e.g. `/tmp/type-slot-checker_<scope>_$$.json` -- the `$$` PID suffix prevents collisions when multiple agents run concurrently.
+- Forward `--max-files N` and (where supported) `--workers N` from the caller.
+- If the script **times out or errors, do NOT retry it.** Fall back to Grep/Read for the same question. Long-running runs should use `run_in_background`.
+
+## Confidence
+
+- **HIGH** -- structurally identical to a known-bad pattern, or exact signature match; >=90% likelihood of being a true positive.
+- **MEDIUM** -- similar with differences that require human verification; 70-89%.
+- **LOW** -- superficially similar; requires code-context reading; 50-69%.
+
+Findings below LOW are not reported.

--- a/plugins/cext-review-toolkit/agents/version-compat-scanner.md
+++ b/plugins/cext-review-toolkit/agents/version-compat-scanner.md
@@ -208,3 +208,18 @@ After all findings, include a summary:
 8. **Verify deprecation claims against documentation.** Do not infer deprecation from nearby functions or from the existence of a replacement API. Only flag an API as deprecated if the CPython documentation explicitly states it, or if it appears in `data/deprecated_apis.json`. For example, `PySys_GetObject` is NOT deprecated even though `PySys_GetAttr` was added in 3.13 — they coexist.
 
 9. **Suggest code removal, not just replacement.** Check `data/deprecated_apis.json` `code_removal_opportunities` section. When the extension's minimum Python version supports a consolidating API (e.g., `PyModule_AddType` on 3.10+), report how many lines of boilerplate could be deleted. Maintainers prefer removing code over adding code. Example: "19 type registrations using `PyType_FromSpec` + `PyType_Ready` + `Py_INCREF` + `PyModule_AddObject` could each be replaced by a single `PyModule_AddType` call, removing ~100 lines."
+
+## Running the script
+
+- Call the script with a Bash timeout of **300000 ms** (5 min). The default 120s kills on large repos.
+- Use a **unique temp filename** for the JSON output, e.g. `/tmp/version-compat-scanner_<scope>_$$.json` -- the `$$` PID suffix prevents collisions when multiple agents run concurrently.
+- Forward `--max-files N` and (where supported) `--workers N` from the caller.
+- If the script **times out or errors, do NOT retry it.** Fall back to Grep/Read for the same question. Long-running runs should use `run_in_background`.
+
+## Confidence
+
+- **HIGH** -- structurally identical to a known-bad pattern, or exact signature match; >=90% likelihood of being a true positive.
+- **MEDIUM** -- similar with differences that require human verification; 70-89%.
+- **LOW** -- superficially similar; requires code-context reading; 50-69%.
+
+Findings below LOW are not reported.

--- a/plugins/cext-review-toolkit/scripts/analyze_history.py
+++ b/plugins/cext-review-toolkit/scripts/analyze_history.py
@@ -13,6 +13,7 @@ Options:
     --until DATE      End date (ISO format, default: today)
     --last N          Analyze exactly the last N commits
     --max-commits N   Cap total commits analyzed (default: 2000)
+    --workers N       Parallel git subprocess workers (default: 8)
     --no-function     Skip function-level churn (file-level only, faster)
 """
 
@@ -22,6 +23,7 @@ import subprocess
 import sys
 import time
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -313,8 +315,12 @@ def _get_py_function_boundaries(filepath: Path) -> list[dict]:
     return functions
 
 
-def compute_function_churn(commits, scan_root, project_root, max_files=0):
-    """Map diff hunks to function boundaries using Tree-sitter/AST."""
+def compute_function_churn(commits, scan_root, project_root, max_files=0, workers=8):
+    """Map diff hunks to function boundaries using Tree-sitter/AST.
+
+    Uses a ThreadPoolExecutor to run per-commit ``git show`` calls in
+    parallel, which is the dominant cost on large histories.
+    """
     file_functions = {}
     if scan_root.is_file():
         all_files = [scan_root]
@@ -362,35 +368,51 @@ def compute_function_churn(commits, scan_root, project_root, max_files=0):
     if not file_functions:
         return []
 
-    func_commits = defaultdict(set)
+    # Collect all (commit_hash, file_path) pairs that need diffs.
+    work_items: list[tuple[str, str]] = []
     for commit in commits:
-        if _check_script_timeout():
-            break
         for file_path in commit["files"]:
-            if file_path not in file_functions:
-                continue
-            try:
-                diff_result = _run_git(
-                    ["show", "--format=", "-U0", commit["hash"], "--", file_path],
-                    project_root,
-                )
-                if diff_result.returncode != 0:
-                    continue
-            except subprocess.TimeoutExpired:
-                continue
+            if file_path in file_functions:
+                work_items.append((commit["hash"], file_path))
 
-            changed_lines = set()
-            for line in diff_result.stdout.splitlines():
-                hunk = re.match(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", line)
-                if hunk:
-                    start = int(hunk.group(1))
-                    count = int(hunk.group(2)) if hunk.group(2) else 1
-                    changed_lines.update(range(start, start + count))
+    def _fetch_hunk(item: tuple[str, str]) -> tuple[str, str, set[int]]:
+        """Fetch changed line numbers for one (commit, file) pair."""
+        commit_hash, file_path = item
+        try:
+            diff_result = _run_git(
+                ["show", "--format=", "-U0", commit_hash, "--", file_path],
+                project_root,
+            )
+            if diff_result.returncode != 0:
+                return commit_hash, file_path, set()
+        except subprocess.TimeoutExpired:
+            return commit_hash, file_path, set()
 
+        changed_lines: set[int] = set()
+        for diff_line in diff_result.stdout.splitlines():
+            hunk = re.match(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", diff_line)
+            if hunk:
+                start = int(hunk.group(1))
+                count = int(hunk.group(2)) if hunk.group(2) else 1
+                changed_lines.update(range(start, start + count))
+        return commit_hash, file_path, changed_lines
+
+    func_commits: dict[tuple[str, str], set[str]] = defaultdict(set)
+    if not work_items:
+        return []
+
+    with ThreadPoolExecutor(max_workers=max(1, workers)) as pool:
+        for commit_hash, file_path, changed_lines in pool.map(
+            _fetch_hunk, work_items
+        ):
+            if _check_script_timeout():
+                break
+            if not changed_lines:
+                continue
             for func in file_functions[file_path]:
                 func_range = set(range(func["line_start"], func["line_end"] + 1))
                 if changed_lines & func_range:
-                    func_commits[(file_path, func["name"])].add(commit["hash"])
+                    func_commits[(file_path, func["name"])].add(commit_hash)
 
     results = []
     for (file_path, func_name), commit_hashes in func_commits.items():
@@ -417,25 +439,53 @@ def _truncate_diff(diff_text, max_lines):
     return "\n".join(lines[:max_lines]) + "\n[diff truncated]"
 
 
-def get_commit_details(commits, commit_type, project_root, scan_root, max_diff_lines):
+def _fetch_one_diff(commit_hash, project_root, rel_scope, max_diff_lines):
+    """Fetch the diff for a single commit. Thread-safe."""
+    diff_args = ["show", "--format=", "--patch", commit_hash, "--"]
+    if rel_scope != ".":
+        diff_args.append(rel_scope)
+    try:
+        dr = _run_git(diff_args, project_root)
+        diff_text = dr.stdout if dr.returncode == 0 else ""
+    except subprocess.TimeoutExpired:
+        diff_text = "[diff unavailable: timeout]"
+    return commit_hash, _truncate_diff(diff_text, max_diff_lines)
+
+
+def get_commit_details(
+    commits, commit_type, project_root, scan_root, max_diff_lines, workers=8
+):
+    """Get details (including diffs) for commits of a given type.
+
+    Fetches diffs in parallel using a thread pool for speed.
+    """
     typed = [c for c in commits if c["type"] == commit_type]
-    results = []
+    if not typed:
+        return []
+
     rel_scope = _relative_scope(scan_root, project_root)
 
+    # Fetch all diffs in parallel.
+    diff_map: dict[str, str] = {}
+    with ThreadPoolExecutor(max_workers=max(1, workers)) as pool:
+        futures = {
+            pool.submit(
+                _fetch_one_diff, c["hash"], project_root,
+                rel_scope, max_diff_lines,
+            ): c["hash"]
+            for c in typed
+        }
+        for future in as_completed(futures):
+            if _check_script_timeout():
+                pool.shutdown(wait=False, cancel_futures=True)
+                break
+            commit_hash, diff_text = future.result()
+            diff_map[commit_hash] = diff_text
+
+    # Assemble results in original commit order.
+    results = []
     for commit in typed:
-        if _check_script_timeout():
-            break
-        diff_args = ["show", "--format=", "--patch", commit["hash"], "--"]
-        if rel_scope != ".":
-            diff_args.append(rel_scope)
-        try:
-            dr = _run_git(diff_args, project_root)
-            diff_text = dr.stdout if dr.returncode == 0 else ""
-        except subprocess.TimeoutExpired:
-            diff_text = "[diff unavailable: timeout]"
-
-        diff_text = _truncate_diff(diff_text, max_diff_lines)
-
+        diff_text = diff_map.get(commit["hash"], "")
         results.append(
             {
                 "commit": commit["hash"],
@@ -487,6 +537,7 @@ def parse_args(argv):
         "last": None,
         "max_commits": 2000,
         "max_files": 0,
+        "workers": 8,
         "no_function": False,
     }
 
@@ -518,6 +569,9 @@ def parse_args(argv):
             i += 2
         elif arg == "--max-files" and i + 1 < len(argv):
             args["max_files"] = _parse_int("--max-files", argv[i + 1])
+            i += 2
+        elif arg == "--workers" and i + 1 < len(argv):
+            args["workers"] = _parse_int("--workers", argv[i + 1])
             i += 2
         elif arg == "--no-function":
             args["no_function"] = True
@@ -566,8 +620,15 @@ def analyze(argv=None):
     try:
         commits, file_churn = parse_git_log(proc.stdout, max_commits, project_root)
     finally:
+        # Terminate git if it's still writing (parse_git_log may have stopped
+        # reading early due to max_commits, which would block git on a full
+        # pipe buffer -> deadlock).
         proc.terminate()
-        proc.wait(timeout=10)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
 
     commit_cap_applied = len(commits) >= max_commits
     if last_n is not None and commits:
@@ -588,23 +649,29 @@ def analyze(argv=None):
         commits_by_type[c["type"]] += 1
         authors.add(c["author"])
 
+    workers = args["workers"]
+
     function_churn = []
     function_churn_note = None
     if args["no_function"] or _check_script_timeout():
         function_churn_note = "Function-level churn skipped"
     else:
         function_churn = compute_function_churn(
-            commits, scan_root, project_root, max_files=args["max_files"]
+            commits, scan_root, project_root,
+            max_files=args["max_files"], workers=workers,
         )
 
     recent_fixes = get_commit_details(
-        commits, "fix", project_root, scan_root, _MAX_DIFF_LINES_FIX
+        commits, "fix", project_root, scan_root, _MAX_DIFF_LINES_FIX,
+        workers=workers,
     )
     recent_features = get_commit_details(
-        commits, "feature", project_root, scan_root, _MAX_DIFF_LINES_FIX
+        commits, "feature", project_root, scan_root, _MAX_DIFF_LINES_FIX,
+        workers=workers,
     )
     recent_refactors = get_commit_details(
-        commits, "refactor", project_root, scan_root, _MAX_DIFF_LINES_REFACTOR
+        commits, "refactor", project_root, scan_root, _MAX_DIFF_LINES_REFACTOR,
+        workers=workers,
     )
 
     co_change_clusters = compute_co_change_clusters(commits)

--- a/plugins/cext-review-toolkit/scripts/scan_common.py
+++ b/plugins/cext-review-toolkit/scripts/scan_common.py
@@ -111,11 +111,16 @@ def discover_c_files(
 
 def load_api_tables() -> dict:
     """Load API classification tables from the data directory."""
+    path = _DATA_DIR / "api_tables.json"
     try:
-        with open(_DATA_DIR / "api_tables.json", encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             return json.load(f)
     except (OSError, json.JSONDecodeError) as e:
-        print(json.dumps({"error": f"Failed to load api_tables.json: {e}"}))
+        print(f"WARNING: Failed to load {path}: {e}", file=sys.stderr)
+        print(
+            json.dumps({"error": f"Failed to load api_tables.json: {e}"}),
+            file=sys.stderr,
+        )
         sys.exit(1)
 
 
@@ -222,6 +227,13 @@ _SAFETY_KEYWORDS = {
     "not a bug",
     "deliberately",
     "expected",
+    "refcount safe",
+    "borrowed ok",
+    "gil held",
+    "gil-held",
+    "already locked",
+    "already protected",
+    "thread-safe",
 }
 
 
@@ -232,6 +244,41 @@ def has_safety_annotation(comments: list[str]) -> bool:
         if any(kw in lower for kw in _SAFETY_KEYWORDS):
             return True
     return False
+
+
+def is_in_region(offset: int, regions: list[tuple[int, int]]) -> bool:
+    """Check if a byte offset falls within any of the given regions."""
+    return any(start <= offset < end for start, end in regions)
+
+
+def make_finding(
+    finding_type: str,
+    *,
+    function: str = "",
+    line: int = 0,
+    classification: str,
+    severity: str,
+    confidence: str = "high",
+    detail: str,
+    **extra: object,
+) -> dict:
+    """Create a finding dict with consistent key naming.
+
+    All scanners produce findings as dicts with a common structure.
+    This helper ensures consistent keys and allows scanner-specific
+    extra fields via **extra.
+    """
+    finding: dict = {
+        "type": finding_type,
+        "function": function,
+        "line": line,
+        "classification": classification,
+        "severity": severity,
+        "confidence": confidence,
+        "detail": detail,
+    }
+    finding.update(extra)
+    return finding
 
 
 def is_suppressed_by_comment(

--- a/plugins/cext-review-toolkit/scripts/scan_resource_lifecycle.py
+++ b/plugins/cext-review-toolkit/scripts/scan_resource_lifecycle.py
@@ -46,6 +46,7 @@ def _load_resource_pairs() -> dict[str, list[str]]:
         with open(pairs_file, encoding="utf-8") as f:
             data = json.load(f)
     except (OSError, json.JSONDecodeError) as e:
+        print(f"WARNING: Failed to load {pairs_file}: {e}", file=sys.stderr)
         print(
             json.dumps({"error": f"Failed to load resource_pairs.json: {e}"}),
             file=sys.stderr,

--- a/plugins/cext-review-toolkit/scripts/scan_version_compat.py
+++ b/plugins/cext-review-toolkit/scripts/scan_version_compat.py
@@ -25,11 +25,16 @@ _DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 
 def _load_deprecated_apis() -> dict:
     """Load deprecated/removed API data."""
+    path = _DATA_DIR / "deprecated_apis.json"
     try:
-        with open(_DATA_DIR / "deprecated_apis.json", encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             return json.load(f)
     except (OSError, json.JSONDecodeError) as e:
-        print(json.dumps({"error": f"Failed to load deprecated_apis.json: {e}"}))
+        print(f"WARNING: Failed to load {path}: {e}", file=sys.stderr)
+        print(
+            json.dumps({"error": f"Failed to load deprecated_apis.json: {e}"}),
+            file=sys.stderr,
+        )
         sys.exit(1)
 
 

--- a/tests/test_analyze_history.py
+++ b/tests/test_analyze_history.py
@@ -114,6 +114,32 @@ class TestAnalyzeHistory(unittest.TestCase):
         self.assertEqual(commits, [])
         self.assertEqual(file_stats, [])
 
+    def test_workers_arg_parsed(self):
+        """--workers N is parsed into args['workers']."""
+        args = history.parse_args(["--workers", "16", "some/path"])
+        self.assertEqual(args["workers"], 16)
+        self.assertEqual(args["path"], "some/path")
+
+    def test_workers_default(self):
+        """Default workers count is 8."""
+        args = history.parse_args([])
+        self.assertEqual(args["workers"], 8)
+
+    def test_workers_invalid_value(self):
+        """Non-integer --workers triggers SystemExit."""
+        with self.assertRaises(SystemExit):
+            history.parse_args(["--workers", "abc"])
+
+    def test_analyze_with_workers_smoke(self):
+        """analyze runs with --workers and returns without hanging."""
+        with TempExtension({"myext.c": MINIMAL_EXTENSION}, init_git=True) as root:
+            _make_commit(root, "fix: thing", {"myext.c": MINIMAL_EXTENSION + "\n"})
+            result = history.analyze(
+                [str(root), "--last", "5", "--workers", "2"]
+            )
+            self.assertNotIn("error", result)
+            self.assertIn("summary", result)
+
     def test_parse_git_log_binary_file(self):
         """parse_git_log handles binary file lines (added/removed are '-')."""
         lines = [

--- a/tests/test_scan_common.py
+++ b/tests/test_scan_common.py
@@ -14,11 +14,21 @@ sys.path.insert(
     ),
 )
 
+import tree_sitter
+import tree_sitter_c
+
 from scan_common import (
     deduplicate_findings,
+    extract_nearby_comments,
     has_safety_annotation,
+    is_in_region,
+    make_finding,
     parse_common_args,
 )
+
+
+_C_LANG = tree_sitter.Language(tree_sitter_c.language())
+_C_PARSER = tree_sitter.Parser(_C_LANG)
 
 
 class TestDeduplicateFindings(unittest.TestCase):
@@ -96,6 +106,144 @@ class TestHasSafetyAnnotation(unittest.TestCase):
 
     def test_deliberately_keyword(self):
         self.assertTrue(has_safety_annotation(["// deliberately not freed"]))
+
+
+class TestExtractNearbyComments(unittest.TestCase):
+    """Tests for extract_nearby_comments()."""
+
+    def _parse(self, source: str):
+        source_bytes = source.encode("utf-8")
+        tree = _C_PARSER.parse(source_bytes)
+        return source_bytes, tree
+
+    def test_finds_comment_on_same_line(self):
+        src = "int x = 1; // safety: intentional\n"
+        src_bytes, tree = self._parse(src)
+        comments = extract_nearby_comments(src_bytes, tree, line=1, radius=1)
+        self.assertTrue(any("safety:" in c for c in comments))
+
+    def test_finds_comment_within_radius(self):
+        src = (
+            "// by design: no check\n"
+            "int f(void) {\n"
+            "    return 0;\n"
+            "}\n"
+        )
+        src_bytes, tree = self._parse(src)
+        comments = extract_nearby_comments(src_bytes, tree, line=3, radius=5)
+        self.assertTrue(any("by design" in c for c in comments))
+
+    def test_ignores_far_comment(self):
+        src = (
+            "// unrelated comment\n"
+            "int a = 1;\n"
+            "int b = 2;\n"
+            "int c = 3;\n"
+            "int d = 4;\n"
+            "int e = 5;\n"
+            "int f = 6;\n"
+            "int g = 7;\n"
+            "int h = 8;\n"
+            "int i = 9;\n"
+        )
+        src_bytes, tree = self._parse(src)
+        comments = extract_nearby_comments(src_bytes, tree, line=10, radius=2)
+        self.assertFalse(any("unrelated" in c for c in comments))
+
+    def test_no_comments_in_source(self):
+        src = "int main(void) { return 0; }\n"
+        src_bytes, tree = self._parse(src)
+        self.assertEqual(extract_nearby_comments(src_bytes, tree, line=1), [])
+
+
+class TestHasSafetyAnnotationExtended(unittest.TestCase):
+    """Cext-specific safety keywords beyond the original minimal test set."""
+
+    def test_gil_held(self):
+        self.assertTrue(has_safety_annotation(["/* gil held */"]))
+        self.assertTrue(has_safety_annotation(["// gil-held"]))
+
+    def test_already_locked(self):
+        self.assertTrue(has_safety_annotation(["// already locked"]))
+
+    def test_refcount_safe(self):
+        self.assertTrue(has_safety_annotation(["/* refcount safe here */"]))
+
+    def test_borrowed_ok(self):
+        self.assertTrue(has_safety_annotation(["// borrowed ok: container lives"]))
+
+    def test_thread_safe(self):
+        self.assertTrue(has_safety_annotation(["// thread-safe access"]))
+
+
+class TestIsInRegion(unittest.TestCase):
+    """Tests for is_in_region()."""
+
+    def test_empty_regions(self):
+        self.assertFalse(is_in_region(10, []))
+
+    def test_inside_region(self):
+        self.assertTrue(is_in_region(15, [(10, 20)]))
+
+    def test_on_start_boundary(self):
+        self.assertTrue(is_in_region(10, [(10, 20)]))
+
+    def test_on_end_boundary_excluded(self):
+        self.assertFalse(is_in_region(20, [(10, 20)]))
+
+    def test_outside_region(self):
+        self.assertFalse(is_in_region(25, [(10, 20)]))
+
+    def test_multiple_regions(self):
+        self.assertTrue(is_in_region(35, [(10, 20), (30, 40)]))
+        self.assertFalse(is_in_region(25, [(10, 20), (30, 40)]))
+
+
+class TestMakeFinding(unittest.TestCase):
+    """Tests for make_finding()."""
+
+    def test_minimal_required_fields(self):
+        f = make_finding(
+            "leak",
+            classification="FIX",
+            severity="high",
+            detail="leaked ref",
+        )
+        self.assertEqual(f["type"], "leak")
+        self.assertEqual(f["classification"], "FIX")
+        self.assertEqual(f["severity"], "high")
+        self.assertEqual(f["confidence"], "high")
+        self.assertEqual(f["detail"], "leaked ref")
+        self.assertEqual(f["function"], "")
+        self.assertEqual(f["line"], 0)
+
+    def test_with_extras(self):
+        f = make_finding(
+            "borrowed_ref_across_call",
+            function="my_func",
+            line=42,
+            classification="FIX",
+            severity="high",
+            confidence="medium",
+            detail="borrowed ref used after call",
+            api_call="PyList_GetItem",
+            variable="item",
+        )
+        self.assertEqual(f["function"], "my_func")
+        self.assertEqual(f["line"], 42)
+        self.assertEqual(f["confidence"], "medium")
+        self.assertEqual(f["api_call"], "PyList_GetItem")
+        self.assertEqual(f["variable"], "item")
+
+    def test_consistent_key_ordering(self):
+        f = make_finding(
+            "t", classification="FIX", severity="low", detail="d",
+        )
+        expected_keys = {
+            "type", "function", "line", "classification",
+            "severity", "confidence", "detail",
+        }
+        self.assertEqual(set(f.keys()), expected_keys)
 
 
 class TestParseCommonArgs(unittest.TestCase):

--- a/tests/test_scan_gil_usage.py
+++ b/tests/test_scan_gil_usage.py
@@ -221,6 +221,9 @@ class TestScanGilUsage(unittest.TestCase):
             result = gil.analyze(str(root / "myext.c"))
             self.assertIn("findings", result)
             self.assertIn("summary", result)
+            # Envelope sanity: data files loaded + at least one function seen.
+            self.assertIn("functions_analyzed", result)
+            self.assertGreaterEqual(result["functions_analyzed"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_scan_module_state.py
+++ b/tests/test_scan_module_state.py
@@ -94,6 +94,9 @@ class TestScanModuleState(unittest.TestCase):
             self.assertIn("findings", result)
             self.assertIn("summary", result)
             self.assertIn("by_type", result["summary"])
+            # Envelope sanity: data files loaded + at least one function seen.
+            self.assertIn("functions_analyzed", result)
+            self.assertGreaterEqual(result["functions_analyzed"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_scan_type_slots.py
+++ b/tests/test_scan_type_slots.py
@@ -154,6 +154,9 @@ class TestScanTypeSlots(unittest.TestCase):
             result = type_slots.analyze(str(root / "typed.c"))
             self.assertIn("findings", result)
             self.assertIn("summary", result)
+            # Envelope sanity: data files loaded + at least one function seen.
+            self.assertIn("functions_analyzed", result)
+            self.assertGreaterEqual(result["functions_analyzed"], 1)
 
 
 TYPE_SPEC_SENTINEL_ZERO = """\

--- a/tests/test_scan_version_compat.py
+++ b/tests/test_scan_version_compat.py
@@ -98,6 +98,9 @@ class TestScanVersionCompat(unittest.TestCase):
             self.assertIn("findings", result)
             self.assertIn("summary", result)
             self.assertIn("min_python", result)
+            # Envelope sanity: data files loaded + at least one function seen.
+            self.assertIn("functions_analyzed", result)
+            self.assertGreaterEqual(result["functions_analyzed"], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR brings cext-review-toolkit back in sync with the two siblings it has diverged from, porting back best-of-breed improvements:

- **From ft-review-toolkit**: shared triage helpers (`make_finding`, `is_in_region`, tuned `_SAFETY_KEYWORDS`) and `extract_nearby_comments` / `has_safety_annotation` already present in cext but now documented alongside the new `make_finding` factory.
- **From cpython-review-toolkit**: `analyze_history.py` parallelization via `ThreadPoolExecutor` with a new `--workers N` flag (default 8), plus a pipe-deadlock hardening fix around the streaming `git log` Popen.
- Silent-failure hardening: all JSON data-file loaders now emit `WARNING: Failed to load <path>: <err>` to stderr before exiting, and scanner tests assert the output envelope (`functions_analyzed`) is non-empty so an empty-data bug can't pass silently.

## Ports from

- **ft-review-toolkit** (triage helpers) — upstream: `plugins/ft-review-toolkit/scripts/scan_common.py`
  - `make_finding(...)` with required `classification`/`severity` plus `**extra` for scanner-specific keys.
  - `is_in_region(offset, regions)` utility.
  - Cext-tuned `_SAFETY_KEYWORDS` (keeps ft's common keywords, drops `mutex held`, adds cext-specific `refcount safe`, `borrowed ok`, `gil held`, `gil-held`, `already locked`, `already protected`, `thread-safe`).
- **cpython-review-toolkit** (history perf patterns) — upstream: `plugins/cpython-review-toolkit/scripts/analyze_history.py`
  - `ThreadPoolExecutor`-based parallel `git show` in `compute_function_churn` and `get_commit_details`.
  - New top-level `_fetch_one_diff` helper, mirrors cpython's pattern.
  - `--workers N` CLI flag, threaded through both churn functions.
  - Pipe-deadlock fix: `proc.terminate()` + `proc.wait(timeout=5)` with `kill()` fallback, wrapped in try/finally around `parse_git_log(proc.stdout, ...)`.

## Notes on `make_finding` adoption

The task's option to "leave alone and note in PR body" applies here: cext's existing scanners produce findings without the `classification`/`severity` keys that `make_finding` requires. Converting all 11 scanners would change every finding's shape (a breaking output change) for the 10 agents that consume them. Instead, `make_finding` is now available in `scan_common` for future scanners and for incremental adoption; existing finding-dict construction is left untouched. The helper is fully unit-tested in `tests/test_scan_common.py`.

## Files changed

- `plugins/cext-review-toolkit/scripts/scan_common.py` — add `make_finding`, `is_in_region`; tune `_SAFETY_KEYWORDS`; stderr-route `load_api_tables` failure with `WARNING:` prefix.
- `plugins/cext-review-toolkit/scripts/analyze_history.py` — `ThreadPoolExecutor` in `compute_function_churn` + `get_commit_details`, new `_fetch_one_diff`, `--workers N` arg, pipe-deadlock hardening with kill-on-timeout fallback.
- `plugins/cext-review-toolkit/scripts/scan_resource_lifecycle.py` — `WARNING:` prefix on data-load failure.
- `plugins/cext-review-toolkit/scripts/scan_version_compat.py` — route data-load failure to stderr with `WARNING:` prefix (was stdout).
- `tests/test_scan_common.py` — new `TestExtractNearbyComments`, `TestHasSafetyAnnotationExtended`, `TestIsInRegion`, `TestMakeFinding`.
- `tests/test_analyze_history.py` — assertions for `--workers` parsing, default, invalid value, and smoke test that `analyze()` returns without hanging under parallel mode.
- `tests/test_scan_gil_usage.py`, `tests/test_scan_module_state.py`, `tests/test_scan_type_slots.py`, `tests/test_scan_version_compat.py` — assert output envelope has non-empty `functions_analyzed`.

## Test plan

- [x] `python -m unittest discover tests` passes locally: **213 tests ran, OK (skipped=5)**.
- [x] Baseline before changes: 191 tests. After changes: 213 tests (+22 new).
- [ ] CI green on this branch.
- [ ] Sanity: `python plugins/cext-review-toolkit/scripts/analyze_history.py . --last 20 --workers 4` runs without hanging.
- [ ] Spot-check: deleting `data/api_tables.json` now produces a `WARNING: Failed to load ...` stderr line (was silent `{}` / stdout JSON).

Do not merge — leave open for review.

https://claude.ai/code/session_01ByAMu9bhKyuV3SXb3dx4xF
