### PR TITLE
feat(q4): add Shape B pointer-field detection (blosc2-shape reinit-leak)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Enhanced
+- **Q4 (`scan_cython_cinit_candidates.py`) gains Shape B detection** (#53): the v0.4.0 Q4 only caught the cymem-shape (`__cinit__` and `__init__` both assigning the same field). Production-agent verification on blosc2 surfaced this as a script gap — the F3 (`SChunk`) and F4 (`NDArray`) reinit-leaks have a different shape: a `cdef <T>* field` declaration, an `__init__` that allocates into it without a free guard, and a `__dealloc__` that frees it. No `__cinit__` is involved. Q4 now applies a second detection pass that triggers on this pointer-field shape and emits FIX HIGH. Validated: catches `SChunk.__init__` (blosc2_ext.pyx:1523) and `NDArray.__init__` (blosc2_ext.pyx:3415), correctly skips `vlmeta` (no `__dealloc__` → non-owning view) and `slice_flatter` (memoryview fields, not raw pointers); cymem `Address.__init__` (cymem.pyx:185) still caught via Shape A with no double-emit. Findings now carry a `details.shape` discriminator (`"overlap"` for Shape A, `"pointer_field"` for Shape B).
+
 ## [0.4.0] - 2026-04-27
 
 ### Added

--- a/plugins/cext-review-toolkit/scripts/scan_cython_cinit_candidates.py
+++ b/plugins/cext-review-toolkit/scripts/scan_cython_cinit_candidates.py
@@ -1,43 +1,54 @@
 #!/usr/bin/env python3
 """scan_cython_cinit_candidates.py — Query 4: detect `__cinit__`/`__init__`
-field-reassignment patterns that leak resources allocated in `__cinit__`.
+reinit-leak patterns in `cdef class` bodies.
 
-The bug pattern (F3-F8 in blosc2, the cymem `Address.__init__` leak):
+Two detection rules are applied:
 
-    cdef class Foo:
+**Shape A: overlap-based (cymem-shape)** -- the original Q4 rule.
+
+    cdef class Address:
         cdef void* ptr
 
         def __cinit__(self, size_t n):
-            self.ptr = malloc(n)              # allocation #1
+            self.ptr = NULL
 
         def __init__(self, size_t n):
-            self.ptr = malloc(n)              # allocation #2 — leaks #1
+            self.ptr = malloc(n)              # __cinit__ also assigns ptr -> leak on re-init
 
-`__cinit__` runs once at construction. `__init__` is Python-level and may run
-multiple times (subclassing, explicit re-call). When `__init__` reassigns a
-field that `__cinit__` already populated -- without freeing the old value
-first -- the old resource leaks.
+Both `__cinit__` and `__init__` assign the same field; `__init__` does not
+free the old value first. Caught by detecting overlapping `self.<field> = ...`
+assignments.
 
-This is most dangerous when the field is a raw C pointer (`void*`, `char*`,
-`cdef struct*`, etc.) because Cython does NOT auto-free those on reassignment.
-For Python `object` fields, Cython's compiler inserts an implicit decref, so
-the bug is benign there. The agent triaging this script's output should check
-the field's declared type to decide severity.
+**Shape B: pointer-field (blosc2-shape)** -- new in v2.
 
-Detection:
-  1. Find every `class_definition` (whether inside a `cdef class` or not).
-  2. Within it, find direct-child `function_definition`s named `__cinit__`
-     and `__init__`.
-  3. Extract the set of fields each method assigns via `self.<field> = ...`.
-  4. For each field assigned in BOTH methods, check whether `__init__`
-     contains a free/decref call referencing that field. If not, emit a
-     candidate.
+    cdef class SChunk:
+        cdef blosc2_schunk *schunk        # raw C-pointer field
+
+        def __init__(self, ...):
+            self.schunk = blosc2_schunk_new(...)  # allocates without free guard
+
+        def __dealloc__(self):
+            if self.schunk is not NULL:
+                blosc2_schunk_free(self.schunk)
+
+There is no `__cinit__` (or it doesn't touch this field), but `__init__`
+allocates into a raw pointer field that `__dealloc__` is responsible for
+freeing. A subclass-induced second `__init__` leaks the first allocation.
+Caught by inspecting class-body field declarations for pointer types and
+correlating with `__init__` allocations + `__dealloc__` ownership.
+
+Cython does NOT auto-free raw C-pointer fields on reassignment (unlike Python
+`object` fields, which it auto-DECREFs). Both shapes are most dangerous on
+those raw pointer fields.
 
 Confidence calibration:
-  - HIGH    : __init__ assigns a `call` expression to the field (likely
-              allocation -- side effect repeats and leaks).
-  - MEDIUM  : __init__ reassigns the field but the RHS isn't an obvious
-              allocation call. May still leak; needs human review.
+  - HIGH (Shape A): __init__ assigns a `call` expression to the field (likely
+                    allocation -- side effect repeats and leaks).
+  - MEDIUM (Shape A): __init__ reassigns the field but the RHS isn't an obvious
+                      allocation call. May still leak; needs human review.
+  - HIGH (Shape B): pointer-field + __init__ allocates + __dealloc__ frees, no
+                    free guard preceding the allocation. Strongest signal --
+                    the dealloc proves the maintainer owns the lifecycle.
 
 Calling convention matches existing scripts:
     analyze(target: str, *, max_files: int = 0) -> dict
@@ -57,18 +68,20 @@ import cython_ast_utils as u
 
 # Free/decref calls that, if present in __init__, suggest the developer is
 # already handling old-value cleanup before reassigning.
-FREE_CALL_NAMES = frozenset({
-    "free",
-    "PyMem_Free",
-    "PyMem_RawFree",
-    "PyObject_Free",
-    "PyObject_GC_Del",
-    "Py_DECREF",
-    "Py_XDECREF",
-    "Py_CLEAR",
-    "Py_XSETREF",
-    "Py_SETREF",
-})
+FREE_CALL_NAMES = frozenset(
+    {
+        "free",
+        "PyMem_Free",
+        "PyMem_RawFree",
+        "PyObject_Free",
+        "PyObject_GC_Del",
+        "Py_DECREF",
+        "Py_XDECREF",
+        "Py_CLEAR",
+        "Py_XSETREF",
+        "Py_SETREF",
+    }
+)
 
 
 def get_self_field_assignments(block_node, source: bytes) -> dict[str, list]:
@@ -133,6 +146,88 @@ def get_function_body(fn_def):
     return None
 
 
+def get_class_pointer_fields(class_block, source: bytes) -> dict[str, str]:
+    """Return {field_name: type_text} for every `cdef <T>* name` field declared
+    directly in the class body. Only raw C-pointer fields qualify -- those are
+    the ones Cython does NOT auto-free on reassignment.
+    """
+    pointer_fields: dict[str, str] = {}
+    for child in class_block.children:
+        if child.type != "cdef_statement":
+            continue
+        cvar = next((c for c in child.children if c.type == "cvar_def"), None)
+        if cvar is None:
+            continue
+        typed = next((c for c in cvar.children if c.type == "maybe_typed_name"), None)
+        if typed is None:
+            continue
+        # A type_modifier child carries the `*`. Without one, this is not a
+        # pointer field (e.g. `cdef int x` or `cdef bint flag`).
+        has_pointer = any(c.type == "type_modifier" for c in typed.children)
+        if not has_pointer:
+            continue
+        idents = [c for c in typed.children if c.type == "identifier"]
+        if len(idents) < 2:
+            continue
+        name_node = idents[-1]
+        name = u.get_text(name_node, source)
+        type_text = (
+            source[typed.start_byte : name_node.start_byte]
+            .decode("utf-8", errors="replace")
+            .strip()
+        )
+        pointer_fields[name] = type_text
+    return pointer_fields
+
+
+def dealloc_references_field(dealloc_block, field: str, source: bytes) -> bool:
+    """True if `self.<field>` text appears anywhere in `__dealloc__`'s body.
+
+    `__dealloc__`'s only purpose is cleanup, so any reference to the field is
+    a strong signal the maintainer takes responsibility for freeing it.
+    """
+    if dealloc_block is None:
+        return False
+    needle = f"self.{field}"
+    return needle in u.get_text(dealloc_block, source)
+
+
+def init_first_alloc_assignment(init_block, field: str, source: bytes):
+    """Return the first `self.<field> = <call>(...)` assignment node in
+    `__init__`, or None. The RHS must include a call expression -- a literal
+    NULL or an integer constant doesn't count as an allocation.
+    """
+    fields = get_self_field_assignments(init_block, source)
+    if field not in fields:
+        return None
+    first_assign = fields[field][0]
+    if len(first_assign.children) < 3:
+        return None
+    rhs = first_assign.children[2]
+    if not any(n.type == "call" for n in u.walk(rhs)):
+        return None
+    return first_assign
+
+
+def init_has_field_use_before(
+    init_block, field: str, source: bytes, before_node
+) -> bool:
+    """True if `__init__` calls anything with `self.<field>` as an argument
+    BEFORE `before_node`'s position. Used as a 'free guard' heuristic -- if
+    the user does anything with the old value before reassigning, presume
+    they handle cleanup correctly.
+    """
+    needle = f"self.{field}"
+    cutoff = before_node.start_byte
+    for call in u.find_nodes(init_block, "call"):
+        if call.start_byte >= cutoff:
+            continue
+        for arg in u.get_call_arguments(call):
+            if needle in u.get_text(arg, source):
+                return True
+    return False
+
+
 def analyze_class(class_def, source: bytes, path: Path) -> list[dict]:
     """Analyze a single class_definition node for cinit/init reinit-leak."""
     findings: list[dict] = []
@@ -150,83 +245,141 @@ def analyze_class(class_def, source: bytes, path: Path) -> list[dict]:
 
     cinit = get_method(class_block, "__cinit__", source)
     init = get_method(class_block, "__init__", source)
-    if cinit is None or init is None:
-        return findings
+    dealloc = get_method(class_block, "__dealloc__", source)
 
-    cinit_body = get_function_body(cinit)
-    init_body = get_function_body(init)
-    if cinit_body is None or init_body is None:
-        return findings
+    init_body = get_function_body(init) if init is not None else None
+    cinit_body = get_function_body(cinit) if cinit is not None else None
+    dealloc_body = get_function_body(dealloc) if dealloc is not None else None
 
-    cinit_fields = get_self_field_assignments(cinit_body, source)
-    init_fields = get_self_field_assignments(init_body, source)
+    # Track (field) keys already flagged so Shape B doesn't double-emit a
+    # finding Shape A already reported.
+    flagged_fields: set[str] = set()
 
-    overlap = sorted(set(cinit_fields) & set(init_fields))
-    if not overlap:
-        return findings
+    # ---- Shape A: overlap-based (cymem-shape) ----
+    if cinit_body is not None and init_body is not None:
+        cinit_fields = get_self_field_assignments(cinit_body, source)
+        init_fields = get_self_field_assignments(init_body, source)
+        overlap = sorted(set(cinit_fields) & set(init_fields))
 
-    for field in overlap:
-        if has_free_call_for_field(init_body, field, source):
-            continue  # developer already handles cleanup -- skip
+        for field in overlap:
+            if has_free_call_for_field(init_body, field, source):
+                continue  # developer already handles cleanup -- skip
 
-        # Inspect the RHS of the FIRST __init__ assignment to gauge severity
-        first_assign = init_fields[field][0]
-        # children: [LHS, "=", RHS]
-        rhs = first_assign.children[2] if len(first_assign.children) >= 3 else None
-        rhs_is_call = rhs is not None and any(
-            n.type == "call" for n in u.walk(rhs)
-        )
+            first_assign = init_fields[field][0]
+            rhs = first_assign.children[2] if len(first_assign.children) >= 3 else None
+            rhs_is_call = rhs is not None and any(n.type == "call" for n in u.walk(rhs))
 
-        if rhs_is_call:
-            classification = "FIX"
-            confidence = "HIGH"
-            severity_note = (
-                "RHS is a function call -- likely allocation. The first "
-                "allocation done in `__cinit__` is leaked when this assignment "
-                "fires."
+            if rhs_is_call:
+                classification = "FIX"
+                confidence = "HIGH"
+                severity_note = (
+                    "RHS is a function call -- likely allocation. The first "
+                    "allocation done in `__cinit__` is leaked when this "
+                    "assignment fires."
+                )
+            else:
+                classification = "CONSIDER"
+                confidence = "MEDIUM"
+                severity_note = (
+                    "RHS is not an obvious allocation. May still leak if the "
+                    "field is a raw C pointer holding a resource; benign if "
+                    "it's a Python `object` field (Cython auto-DECREFs)."
+                )
+
+            line = first_assign.start_point[0] + 1
+            column = first_assign.start_point[1] + 1
+
+            findings.append(
+                u.make_finding(
+                    file=path,
+                    line=line,
+                    column=column,
+                    function=f"{class_name}.__init__" if class_name else "__init__",
+                    category="cinit_init_reinit_leak",
+                    classification=classification,
+                    confidence=confidence,
+                    description=(
+                        f"`{class_name}.__init__` reassigns `self.{field}` "
+                        f"which `__cinit__` already populated, without freeing "
+                        f"the old value first. {severity_note}"
+                    ),
+                    fix_template=(
+                        f"Either (a) move the assignment out of `__init__` "
+                        f"(let `__cinit__` own the field), (b) free the old "
+                        f"value first: `if self.{field} is not NULL: "
+                        f"free(self.{field})`, or (c) make `__init__` a no-op "
+                        f"and document that re-initialization is unsupported."
+                    ),
+                    details={
+                        "shape": "overlap",
+                        "class": class_name,
+                        "field": field,
+                        "cinit_line": cinit_fields[field][0].start_point[0] + 1,
+                        "init_line": line,
+                        "rhs_is_call": rhs_is_call,
+                    },
+                )
             )
-        else:
-            classification = "CONSIDER"
-            confidence = "MEDIUM"
-            severity_note = (
-                "RHS is not an obvious allocation. May still leak if the field "
-                "is a raw C pointer holding a resource; benign if it's a Python "
-                "`object` field (Cython auto-DECREFs)."
-            )
+            flagged_fields.add(field)
 
-        line = first_assign.start_point[0] + 1
-        column = first_assign.start_point[1] + 1
+    # ---- Shape B: pointer-field (blosc2-shape) ----
+    # Trigger when: init allocates a raw C-pointer field that __dealloc__ owns,
+    # without a free guard preceding the allocation. __cinit__ may be absent.
+    if init_body is not None and dealloc_body is not None:
+        pointer_fields = get_class_pointer_fields(class_block, source)
+        for field, type_text in pointer_fields.items():
+            if field in flagged_fields:
+                continue  # already reported under Shape A
+            if not dealloc_references_field(dealloc_body, field, source):
+                continue  # __dealloc__ doesn't manage this field
+            alloc_assign = init_first_alloc_assignment(init_body, field, source)
+            if alloc_assign is None:
+                continue  # __init__ doesn't allocate into this field
+            if init_has_field_use_before(init_body, field, source, alloc_assign):
+                continue  # presume free guard or other safe handling
+            if has_free_call_for_field(init_body, field, source):
+                continue  # explicit known-free call somewhere -- safe
 
-        findings.append(
-            u.make_finding(
-                file=path,
-                line=line,
-                column=column,
-                function=f"{class_name}.__init__" if class_name else "__init__",
-                category="cinit_init_reinit_leak",
-                classification=classification,
-                confidence=confidence,
-                description=(
-                    f"`{class_name}.__init__` reassigns `self.{field}` which "
-                    f"`__cinit__` already populated, without freeing the old "
-                    f"value first. {severity_note}"
-                ),
-                fix_template=(
-                    f"Either (a) move the assignment out of `__init__` (let "
-                    f"`__cinit__` own the field), (b) free the old value "
-                    f"first: `if self.{field} is not NULL: free(self.{field})`, "
-                    f"or (c) make `__init__` a no-op and document that "
-                    f"re-initialization is unsupported."
-                ),
-                details={
-                    "class": class_name,
-                    "field": field,
-                    "cinit_line": cinit_fields[field][0].start_point[0] + 1,
-                    "init_line": line,
-                    "rhs_is_call": rhs_is_call,
-                },
+            line = alloc_assign.start_point[0] + 1
+            column = alloc_assign.start_point[1] + 1
+
+            findings.append(
+                u.make_finding(
+                    file=path,
+                    line=line,
+                    column=column,
+                    function=f"{class_name}.__init__" if class_name else "__init__",
+                    category="cinit_init_reinit_leak",
+                    classification="FIX",
+                    confidence="HIGH",
+                    description=(
+                        f"`{class_name}.__init__` allocates the raw C-pointer "
+                        f"field `self.{field}` (declared `{type_text} *{field}`) "
+                        f"without freeing the prior value first. `__dealloc__` "
+                        f"manages this field, proving the maintainer owns its "
+                        f"lifecycle -- but a subclass-induced second `__init__` "
+                        f"call leaks the first allocation."
+                    ),
+                    fix_template=(
+                        f"Either (a) move the allocation into `__cinit__` "
+                        f"(runs exactly once), (b) free the old value first: "
+                        f"`if self.{field} is not NULL: <free_func>(self.{field})`, "
+                        f"or (c) make `__init__` a no-op and document that "
+                        f"re-initialization is unsupported."
+                    ),
+                    details={
+                        "shape": "pointer_field",
+                        "class": class_name,
+                        "field": field,
+                        "field_type": type_text,
+                        "init_line": line,
+                        "dealloc_line": dealloc.start_point[0] + 1
+                        if dealloc is not None
+                        else None,
+                        "cinit_present": cinit is not None,
+                    },
+                )
             )
-        )
 
     return findings
 
@@ -265,7 +418,9 @@ def analyze(target: str, *, max_files: int = 0) -> dict:
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0] if __doc__ else "")
+    ap = argparse.ArgumentParser(
+        description=__doc__.split("\n", 1)[0] if __doc__ else ""
+    )
     ap.add_argument("target", help=".pyx file or directory to scan")
     ap.add_argument("--max-files", type=int, default=0)
     args = ap.parse_args()

--- a/tests/test_scan_cython_cinit_candidates.py
+++ b/tests/test_scan_cython_cinit_candidates.py
@@ -64,6 +64,71 @@ cdef class WithInteger:
         self.flag = 1
 """
 
+# Shape B: blosc2-shape pointer-field. No __cinit__; __init__ allocates a
+# raw C-pointer field that __dealloc__ owns. Should fire FIX HIGH.
+POINTER_FIELD_LEAK = """\
+cdef class SChunk:
+    cdef blosc2_schunk *schunk
+    cdef bint _is_view
+
+    def __init__(self, ...):
+        self.schunk = blosc2_schunk_new(storage)
+
+    def __dealloc__(self):
+        if self.schunk is not NULL:
+            blosc2_schunk_free(self.schunk)
+"""
+
+# Shape B safe variant: __init__ checks NULL and frees before reassign.
+POINTER_FIELD_SAFE_GUARD = """\
+cdef class Safe:
+    cdef blosc2_schunk *schunk
+
+    def __init__(self, ...):
+        if self.schunk is not NULL:
+            blosc2_schunk_free(self.schunk)
+        self.schunk = blosc2_schunk_new(storage)
+
+    def __dealloc__(self):
+        if self.schunk is not NULL:
+            blosc2_schunk_free(self.schunk)
+"""
+
+# Shape B: borrowed view -- has pointer field but NO __dealloc__. Must NOT
+# fire (the maintainer is signalling non-ownership).
+BORROWED_VIEW = """\
+cdef class vlmeta:
+    cdef blosc2_schunk *schunk
+
+    def __init__(self, schunk_ptr):
+        self.schunk = <blosc2_schunk*> <uintptr_t> schunk_ptr
+"""
+
+# Shape B: pointer field but __init__'s RHS is a cast, not a call. Must NOT
+# fire (no allocation happened).
+POINTER_FIELD_CAST_ONLY = """\
+cdef class CastOnly:
+    cdef blosc2_schunk *schunk
+
+    def __init__(self, raw):
+        self.schunk = <blosc2_schunk*> raw
+
+    def __dealloc__(self):
+        pass
+"""
+
+# Shape B with a non-pointer field. Must NOT fire (Cython auto-manages).
+NON_POINTER_FIELD = """\
+cdef class Plain:
+    cdef int flag
+
+    def __init__(self):
+        self.flag = compute_flag()
+
+    def __dealloc__(self):
+        pass
+"""
+
 
 class TestQ4Detection(unittest.TestCase):
     def test_leaky_high_confidence(self):
@@ -112,6 +177,77 @@ class TestQ4Detection(unittest.TestCase):
             result = q4.analyze(str(root / "x.pyx"))
         self.assertEqual(result["script"], "scan_cython_cinit_candidates")
         self.assertEqual(result["stats"]["files_scanned"], 1)
+
+    def test_shape_a_marked_in_details(self):
+        with TempExtension({"x.pyx": LEAKY}) as root:
+            result = q4.analyze(str(root / "x.pyx"))
+        self.assertEqual(result["findings"][0]["details"]["shape"], "overlap")
+
+
+class TestQ4ShapeBPointerField(unittest.TestCase):
+    """Shape B: blosc2-shape pointer-field reinit-leak (added in v2)."""
+
+    def test_pointer_field_leak_flagged_high(self):
+        with TempExtension({"x.pyx": POINTER_FIELD_LEAK}) as root:
+            result = q4.analyze(str(root / "x.pyx"))
+        self.assertEqual(len(result["findings"]), 1)
+        f = result["findings"][0]
+        self.assertEqual(f["classification"], "FIX")
+        self.assertEqual(f["confidence"], "HIGH")
+        self.assertEqual(f["details"]["shape"], "pointer_field")
+        self.assertEqual(f["details"]["field"], "schunk")
+        self.assertEqual(f["details"]["field_type"], "blosc2_schunk *")
+        self.assertEqual(f["details"]["class"], "SChunk")
+        self.assertFalse(f["details"]["cinit_present"])
+
+    def test_safe_guard_not_flagged(self):
+        with TempExtension({"x.pyx": POINTER_FIELD_SAFE_GUARD}) as root:
+            result = q4.analyze(str(root / "x.pyx"))
+        self.assertEqual(result["findings"], [])
+
+    def test_borrowed_view_not_flagged(self):
+        # No __dealloc__ -> non-owning -> must skip
+        with TempExtension({"x.pyx": BORROWED_VIEW}) as root:
+            result = q4.analyze(str(root / "x.pyx"))
+        self.assertEqual(result["findings"], [])
+
+    def test_cast_only_not_flagged(self):
+        # RHS is a cast, not a call -> not an allocation -> must skip
+        with TempExtension({"x.pyx": POINTER_FIELD_CAST_ONLY}) as root:
+            result = q4.analyze(str(root / "x.pyx"))
+        self.assertEqual(result["findings"], [])
+
+    def test_non_pointer_field_not_flagged(self):
+        # Non-pointer field -> Cython manages -> must skip
+        with TempExtension({"x.pyx": NON_POINTER_FIELD}) as root:
+            result = q4.analyze(str(root / "x.pyx"))
+        self.assertEqual(result["findings"], [])
+
+    def test_shape_a_does_not_double_emit_under_b(self):
+        # The cymem-shape LEAKY has overlap (Shape A). Even though `ptr` is
+        # a `void*` pointer field with __dealloc__-style ownership, we must
+        # only get one finding (Shape A wins; flagged_fields prevents B).
+        # Note: LEAKY in this fixture doesn't declare a __dealloc__, so this
+        # is implicitly tested -- but we can construct one that does.
+        src = """\
+cdef class Both:
+    cdef void *ptr
+
+    def __cinit__(self):
+        self.ptr = NULL
+
+    def __init__(self):
+        self.ptr = malloc(10)
+
+    def __dealloc__(self):
+        if self.ptr is not NULL:
+            free(self.ptr)
+"""
+        with TempExtension({"x.pyx": src}) as root:
+            result = q4.analyze(str(root / "x.pyx"))
+        # Should be exactly 1 finding (Shape A overlap), not 2
+        self.assertEqual(len(result["findings"]), 1)
+        self.assertEqual(result["findings"][0]["details"]["shape"], "overlap")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds a second detection pass to Q4 (`scan_cython_cinit_candidates.py`) for the **pointer-field shape** that the v0.4.0 Q4 missed: `cdef <T>* field` declaration + `__init__` allocates into it + `__dealloc__` frees it, with no `__cinit__` required.
- Emits **FIX HIGH** when all four conditions hold (pointer field, init allocates via call, no preceding free guard, dealloc references field).
- Findings now carry a `details.shape` discriminator: `"overlap"` (Shape A, cymem-shape) or `"pointer_field"` (Shape B, blosc2-shape).

## Test plan
- [x] Catches blosc2 `SChunk.__init__` (blosc2_ext.pyx:1523) — F3
- [x] Catches blosc2 `NDArray.__init__` (blosc2_ext.pyx:3415) — F4
- [x] Skips `vlmeta` (no `__dealloc__` → borrowed view, correct)
- [x] Skips `slice_flatter` (memoryview fields, not raw pointers, correct)
- [x] cymem `Address.__init__` (cymem.pyx:185) still caught via Shape A, no double-emit when both shapes apply
- [x] 7 new unit tests covering Shape B fixtures + no-double-emit invariant
- [x] All 271 tests pass (264 prior + 7 new); ruff format/check clean; mypy clean

Closes #53

Generated with [Claude Code](https://claude.com/claude-code)