### PR TITLE
feat: revise Cython skip-strategy + Cython-mode for kept agents (v0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-27
+
+### Changed
+- **Cython skip-strategy revised** (`commands/explore.md` Code Generation Strategy section). Calibrated against a comprehensive uvloop 0.22.1 review (`reports/uvloop_v3/`) where every skipped agent was evaluated with one naive pass:
+  - **`parity-checker` moved OUT of the Cython skip list**: its `.pyi`-vs-`.pyx` adapted-scope check found 1 FIX HIGH (`sock_recvfrom`/`sock_sendto`/`sock_recvfrom_into` advertised in stub but raise NotImplementedError) + 1 CONSIDER that no other agent in the toolkit can find. No other agent reads `.pyi` stubs.
+  - **`error-path-analyzer`, `null-safety-scanner`, `pyerr-clear-auditor`, `refcount-auditor`** confirmed as skip-by-default (validated zero FIX-class loss on uvloop).
+  - **`module-state-checker`, `c-complexity-analyzer`, `version-compat-scanner`, `stable-abi-checker`** moved to a new "run on Cython for deep-effort reviews" tier — skip by default, but produce real CONSIDER/POLICY findings on Cython projects when invoked (~100 cached-import subinterpreter blocker, .pyx-source-level complexity refactors, dead version guards, abi3 feasibility assessment).
+
+### Added
+- **Cython-mode sections in 5 agent prompts** documenting what each agent can find on Cython projects when not skipped:
+  - `agents/parity-checker.md`: adapted scope (`.pyi` ↔ `.pyx` method-set parity, stdlib-equivalent semantics, twin-class divergence, public API/docs parity) — primary check on Cython.
+  - `agents/module-state-checker.md`: cached `static PyObject*` imports outside module state, module-level `cdef` C globals, lazy-init flags, GC traverse/clear coverage, subinterpreter posture.
+  - `agents/c-complexity-analyzer.md`: walk `.pyx` source-level complexity directly (do not use C-level metrics on Cython codegen), identify maintainer-visible refactor targets.
+  - `agents/version-compat-scanner.md`: hand-written C in `includes/*.h`, dead version guards, private-API `_Py_*` reimplementations, Cython 4 readiness.
+  - `agents/stable-abi-checker.md`: distinguish maintainer abi3 claim from Cython runtime opt-in (`cython_limited_api=True`), audit hand-written C macro use, produce per-project feasibility assessment.
+- **`type_stubs` field in `discover_extension.py` output** — lists `.pyi` files in the project, signaling parity-checker that Cython mode is applicable. Skips `build/`, `dist/`, `__pycache__/` and hidden directories. Three new tests in `test_discover_extension.py`.
+
+### Notes
+- The skip-strategy revision applies to invocations through `/cext-review-toolkit:explore`. For deep-effort reviews on Cython projects, the four "deep-effort tier" agents can be explicitly listed.
+- Agent prompt Cython-mode sections include uvloop 0.22.1 reference findings as concrete calibration data, so future runs on similar Cython projects (libuv/libev/llhttp bindings, asyncio replacements, generic Cython-wrapped-C libraries) have a tested template to draw on.
+
 ## [0.4.1] - 2026-04-27
 
 ### Enhanced

--- a/plugins/cext-review-toolkit/.claude-plugin/plugin.json
+++ b/plugins/cext-review-toolkit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cext-review-toolkit",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "CPython C/C++ extension analysis agents: refcount auditing (with borrowed-ref-across-callback detection), error path analysis, NULL safety scanning, GIL discipline checking, module state validation, type slot correctness, stable ABI compliance, version compatibility scanning, PyErr_Clear auditing, resource lifecycle tracking, C/Python parity checking, complexity measurement, and git history analysis. Tree-sitter-powered C/C++ parsing with optional clang-tidy/cppcheck integration.",
   "author": {
     "name": "Danzin"

--- a/plugins/cext-review-toolkit/agents/c-complexity-analyzer.md
+++ b/plugins/cext-review-toolkit/agents/c-complexity-analyzer.md
@@ -18,6 +18,26 @@ If `reports/<extension>_v1/preflight/generated_code_map.md` exists, **read it be
 
 If no preflight exists, proceed normally.
 
+## Cython mode (deep-effort runs)
+
+You are SKIPPED BY DEFAULT on Cython projects because `measure_c_complexity.py` operating on the generated `.c` is unreliable — Cython codegen artifacts (uniform `goto __PYX_L*_error;` cleanup, `__pyx_pf_*` wrapper machinery) produce artificially high cyclomatic-complexity scores on every function regardless of maintainer intent. When invoked on a Cython project for a deep-effort review, switch to the **Cython-adapted scope**:
+
+1. **Walk `.pyx` source-level complexity directly**. Do NOT use the C-level metrics — the .c is mostly Cython runtime. Instead, walk each `.pyx` file with a simple Python script: count `def`/`cdef` function bodies by indent, measure LOC and max nesting depth of each. Cyclomatic-ish: count `if`/`elif`/`for`/`while`/`try`/`except`/`with`. This gives you the maintainer-visible complexity at the source-of-truth.
+
+2. **Hot spots to expect on event-loop / I/O Cython projects**: `Loop.create_*` async methods (server/connection/datagram_endpoint) often top 200 LOC with nesting ≥9 due to AF_INET/AF_INET6/AF_UNIX cascade and addrinfo-iteration. `__convert_pyaddr_to_sockaddr`-style helpers are common per-family-cascade refactor targets.
+
+3. **Hand-written C in `includes/*.h`** is in scope for the original C-level metrics but is usually trivial (uvloop's headers are ~200 LOC total). Run the standard tool there, not on the generated `.c`.
+
+4. **The 23+ libuv-callback bodies** in handles/ are hand-written by the maintainer in `.pyx` and may have grown complex. Audit each `cdef ... noexcept with gil:` for LOC and nesting.
+
+5. **Output**: top-N hotspots ranked by **`.pyx`-source complexity** (NOT C-level). For each, brief simplification suggestion (extract helper, split per-family, flatten nesting via early returns).
+
+6. **Reference**: uvloop 0.22.1 — `Loop.create_server` (loop.pyx:1636, 214 LOC, nest 11), `Loop.create_connection` (loop.pyx:1850, 236 LOC, nest 9), `__convert_pyaddr_to_sockaddr` (dns.pyx:82, 98 LOC, nest 8) — all CONSIDER refactor targets surfaced in v3 review.
+
+7. **What to NOT flag**: `Loop.__cinit__` (long but flat — fork/signal plumbing mirrors CPython), `_print_debug_info` (flat sequence of `print()` statements), perf fast/slow path splits in `_exec_write` etc. — these are inherent complexity, ACCEPTABLE.
+
+If nothing substantive: "Cython mode: no maintainer-actionable complexity items; .pyx-level sources are trim."
+
 ## Key Concepts
 
 Complexity in C extensions arises from several measurable dimensions:

--- a/plugins/cext-review-toolkit/agents/module-state-checker.md
+++ b/plugins/cext-review-toolkit/agents/module-state-checker.md
@@ -18,6 +18,25 @@ If `reports/<extension>_v1/preflight/generated_code_map.md` exists, **read it be
 
 If no preflight exists, proceed normally.
 
+## Cython mode (deep-effort runs)
+
+You are SKIPPED BY DEFAULT on Cython projects (low FIX yield from generator-emitted module init). When invoked on a Cython project for a deep-effort review, switch to the **Cython-adapted scope** — your standard PEP 489 multi-phase init checks are mostly handled by Cython's codegen; instead look for module-state issues that survive that filter:
+
+1. **Module-level `static PyObject*` cached imports outside module state** — Cython projects commonly use `.pxi` include files (e.g. `includes/stdlib.pxi`) declaring `cdef object some_module = None` followed by lazy initialization in module init. These compile to `static PyObject*` at file scope, NOT registered in the `__pyx_m_traverse` / `__pyx_m_clear` set. They are subinterpreter blockers and cycle-collection blind spots. **Reference**: uvloop `includes/stdlib.pxi:28-167` declares ~100 such cached imports. Find all `.pxi` files and audit them.
+2. **Module-level `cdef` C globals** — search for `cdef <T> NAME` at module scope (not inside any class/function). These are pure C globals, never module-state, never freed. Examples from uvloop: `MAIN_THREAD_ID`, `MAIN_THREAD_ID_SET`, `__forkHandler` in `includes/fork_handler.h`. Often subinterpreter blockers.
+3. **Module-level `static <ClassType>*` pointers** — e.g. `static Loop* __forking_loop` at uvloop loop.pyx:3361. Same concerns as #2.
+4. **Lazy-init flags** — `__atfork_installed`, `__mem_installed`, etc. Test-and-set on module-level flags is FT-fragile (overlap with gil-discipline-checker, but the module-state angle is the lifecycle, not the race).
+5. **GC traverse/clear coverage** — Cython 3.2+ generates `__pyx_m_traverse`/`__pyx_m_clear` automatically for module-state-converted projects. Verify the `cdef object` declarations at module scope are visited; verify `cdef <PyType>` declarations are visited via the heap-type infrastructure.
+6. **Subinterpreter posture** — check the `Py_mod_multiple_interpreters` slot in the generated `.c`. `Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED` is the correct posture if any of #1-#3 apply; record this as POLICY rather than FIX.
+7. **`.pxd` cimport'd module state** — if the project has `cimport` of another module's `cdef object` declarations (rare), audit that the cross-module state is per-interpreter.
+
+For each finding, classify:
+- **CONSIDER** — surfacing the global as a subinterpreter blocker or cycle/reload concern.
+- **POLICY** — when the maintainer's `Py_mod_multiple_interpreters` posture is consistent with the globals (they've documented the trade-off).
+- **FIX** — only if you find a global that's mutated unsynchronized AND `freethreading_compatible=True` is asserted (overlap with gil-discipline-checker, but distinct angle).
+
+If nothing substantive: "Cython mode: no module-state issues beyond Cython codegen pattern."
+
 ## Key Concepts
 
 Module state management in C extensions has evolved:

--- a/plugins/cext-review-toolkit/agents/parity-checker.md
+++ b/plugins/cext-review-toolkit/agents/parity-checker.md
@@ -18,6 +18,31 @@ If `reports/<extension>_v1/preflight/generated_code_map.md` exists, **read it be
 
 If no preflight exists, proceed normally.
 
+## Cython mode (NEW: skip-strategy disprover)
+
+If the project is a Cython binding (the preflight will say so), the standard "C vs Python fallback" parity surface is usually empty — Cython projects rarely ship dual implementations. **You are still NOT skipped on Cython projects.** Switch to the **adapted parity scope** below — you will likely find bugs no other agent in the toolkit can find.
+
+### Adapted Cython parity scope (apply IN ORDER)
+
+1. **`.pyi` ↔ `.pyx` method-set parity** — **highest-value check on Cython.** No other agent in the toolkit reads `.pyi` stubs. For each `.pyi` file in the project:
+   - Cross-reference every advertised method/function/attribute against the actual `.pyx` implementation.
+   - Flag entries advertised in `.pyi` with full signatures but **missing entirely from `.pyx`** (the stub author may have written them to fool mypy — happens when stdlib added an API uvloop hasn't yet implemented).
+   - Flag entries advertised in `.pyi` as functional but **raising `NotImplementedError` in `.pyx`**. This breaks any drop-in-replacement contract with stdlib.
+   - Flag entries with diverging signatures (different parameter types, return types, default values).
+   - **Reference**: uvloop 0.22.1 — `loop.pyi:289-296` advertises `sock_recvfrom`/`sock_recvfrom_into`/`sock_sendto` as functional, but `loop.pyx:2631-2639` raises `NotImplementedError`. Stdlib `BaseEventLoop` implements all three since Python 3.11. **FIX HIGH** — drop-in-replacement contract broken.
+
+2. **Stdlib-equivalent parity** — when a Cython project re-implements a stdlib API (uvloop ↔ asyncio; numexpr ↔ numpy; cassandra-driver ↔ stdlib socket): does error TYPE match (OSError vs BlockingIOError vs ConnectionError)? Does timeout precision match? Does callback ordering match? Does short-read/partial-write semantics match? Cite the specific stdlib reference for each divergence.
+
+3. **Twin-class divergence within the project** (parity in disguise): Cython projects often have parallel `cdef class` families that implement the same role (uvloop's UVStream/UVPipe/TCPTransport, _StreamWriteContext/_UDPSendContext). For each cluster:
+   - Map the public API surface across all twins
+   - Identify behavioral differences (error handling, refcount-pin order, partial-init cleanup, factory-method validation)
+   - Flag the divergent ones — the rule of thumb: when one is correct and another is buggy, the buggy one is likely a fix-completeness gap that didn't propagate when the second class was added years later.
+   - **Reference**: uvloop `_StreamWriteContext.new` (correct, 2016) vs `_UDPSendContext.new` (buggy, 2019) — same role, the udp version was added without inheriting the stream version's `Py_INCREF`-after-fallible discipline.
+
+4. **Public API documentation parity** — does `README.md`/docs claim feature support that `.pyx` doesn't honor? Does the `__all__` list in `__init__.py` map cleanly to actual exports? Does the maintainer's compatibility matrix match what the code does?
+
+If you find nothing in adapted scope: report "No parity findings; Cython project has no dual implementations and `.pyi`/stdlib/twin-class checks all clean."
+
 ## Why This Matters
 
 Extensions with dual implementations (C fast path + Python fallback) create a subtle attack surface:

--- a/plugins/cext-review-toolkit/agents/stable-abi-checker.md
+++ b/plugins/cext-review-toolkit/agents/stable-abi-checker.md
@@ -18,6 +18,35 @@ If `reports/<extension>_v1/preflight/generated_code_map.md` exists, **read it be
 
 If no preflight exists, proceed normally.
 
+## Cython mode (deep-effort runs)
+
+You are SKIPPED BY DEFAULT on Cython projects because the typical answer is "doesn't claim abi3 → assess feasibility (often Hard)". When invoked on a Cython project for a deep-effort review, the answer is more nuanced — Cython has its OWN abi3 mode that's separate from the maintainer's claim:
+
+1. **Distinguish the two abi3 mechanisms** Cython projects can use:
+   - **Maintainer's `Py_LIMITED_API`** — defined directly in extension config (e.g. `Extension(..., py_limited_api=True)` or `define_macros=[('Py_LIMITED_API', '0x03070000')]`).
+   - **Cython's `cython_limited_api=True`** — passed to `cythonize(..., cython_limited_api=True)` or via `language_level=3` + `--3limited` flag. Cython 3.0+ supports this.
+   - **Both must be set** for an end-to-end abi3 build. Neither alone is enough.
+
+2. **Verify the artifact name** — abi3 builds produce `*.abi3.so`, not the versioned `*.cpython-3XY-*.so`. Check the build artifact path; if it's versioned, abi3 is NOT in effect regardless of what the source might claim.
+
+3. **Audit hand-written C in `includes/*.h`** for stable-ABI compatibility (this is the small-but-real surface):
+   - Macro use of `PyBytes_AS_STRING`, `Py_SIZE`, `PyTuple_GET_ITEM`, etc. — these are NOT in the limited API. Often deliberate for performance hot paths. **Reference**: uvloop uses `PyBytes_AS_STRING` + `Py_SIZE` in stream.pyx:158-159,367-368 (hot write path).
+   - Direct struct field access (`ob_refcnt`, `tp_name`, etc.) — never in limited API.
+   - Private `_Py_*` symbols — never in limited API. **Reference**: uvloop `compat.h:88-105` reimplements `_Py_RestoreSignals` locally; the symbol becoming private blocks abi3 entirely until removed.
+   - Version-conditional fork/signal/threading paths — `#if PY_VERSION_HEX >= 0x030B0000` style guards typically use APIs that vary across versions.
+
+4. **Cython runtime opt-in audit** — even if the maintainer adds `py_limited_api=True`, Cython 3.x must ALSO be told via `cython_limited_api=True`. Check `setup.py`'s `cythonize(...)` call AND any `pyproject.toml` `[tool.cython]` section.
+
+5. **Feasibility assessment template** for the report:
+   - **API surface**: list non-stable APIs used in `.pyx` (Cython's `cdef extern from "Python.h"` declarations) and `includes/*.h`. Cite each macro use.
+   - **Min Python version for abi3**: `PyMem_Raw*` since 3.13, `PyObject_GetBuffer` since 3.11, etc. — most uvloop-class APIs need 3.13 floor.
+   - **Operational blockers**: per-Python-minor wheels already produced (e.g. via libuv vendoring), version-conditional code paths, hot-path macro use that's deliberate.
+   - **POLICY recommendation**: typical answer for libuv/libev/llhttp-style native bindings is "abi3 not feasible due to vendored-native + per-minor wheel + hot-path macros." Document and revisit on Cython limited-API extension or when CPython stabilizes more APIs.
+
+6. **Reference**: uvloop 0.22.1 — POLICY abi3 not feasible due to (a) Cython runtime opt-in not set, (b) deliberate macro use, (c) version-conditional paths PY39/PY311/PY313 at loop.pyx:51-53, (d) libuv vendoring already producing per-minor wheels.
+
+If the project IS abi3-claimed, run the standard verification steps below — but verify the `.abi3.so` artifact actually exists, not just the `Py_LIMITED_API` macro.
+
 ## Key Concepts
 
 Python provides two levels of API restriction:

--- a/plugins/cext-review-toolkit/agents/version-compat-scanner.md
+++ b/plugins/cext-review-toolkit/agents/version-compat-scanner.md
@@ -18,6 +18,41 @@ If `reports/<extension>_v1/preflight/generated_code_map.md` exists, **read it be
 
 If no preflight exists, proceed normally.
 
+## Cython mode (deep-effort runs)
+
+You are SKIPPED BY DEFAULT on Cython projects because the standard scope (deprecated CPython APIs, version-guarded `#if PY_VERSION_HEX` blocks, pythoncapi-compat opportunities) is mostly handled by Cython's runtime and codegen. When invoked on a Cython project for a deep-effort review, switch to the **Cython-adapted scope** — there are real findings that survive the generator filter:
+
+1. **Hand-written C in `includes/*.h`** — this is the main audit surface. Cython projects commonly have `compat.h`, `fork_handler.h`, `debug.h` with hand-written `#if PY_VERSION_HEX` blocks. Audit these for:
+   - **Dead version guards** — if `pyproject.toml` declares `requires-python = '>=3.X'`, any `#if PY_VERSION_HEX < 0x030X0000` branch is dead. **Reference**: uvloop `compat.h:58-86` has dead `#if PY_VERSION_HEX < 0x03070100` for Python <3.7.1 (29 lines collapsible to ~14).
+   - **Private-API `_Py_*` reimplementations** — when CPython internalizes a previously-public API, projects re-implement it locally. This is a correct strategy but should be (a) version-conditional, (b) match CPython's contract per supported version, (c) have a comment citing the upstream change. **Reference**: uvloop `compat.h:88-105` reimplements `_Py_RestoreSignals` after CPython 3.13's python/cpython#106400. Local definition shadows the CPython symbol — correct strategy. Note that `python.pxd:31` mis-attributes the source as `Python.h` rather than the local file; flag as POLICY.
+   - **Direct CPython struct field access** — `tp_*`, `ob_*`, etc. — would block any future abi3 attempt; coordinate with stable-abi-checker.
+
+2. **Cython 4 readiness** — `setup.py` and `pyproject.toml` may pin `cython` differently:
+   - Check both files. Verify upper bound `<4` is set (e.g. `~=3.x`, `>=3,<4`).
+   - **Reference correction from uvloop eval**: `setup.py` pins `Cython~=3.0`, `pyproject.toml` pins `Cython~=3.1`; both upper-bounded `<4`. Cython 4 risk is LOW for projects that pin like this, NOT "unbounded" as a casual reading might suggest.
+   - Check `language_level=3` (current; not the deprecated `3str`).
+   - Check for deprecated Cython directives — see Cython 3.x → 4.0 migration docs.
+
+3. **Deprecated Cython directives** in `.pyx` files. Search for `# cython:` lines in all `.pyx`/`.pxd` and audit each directive:
+   - `language_level=2` → deprecated, must update to 3
+   - `c_string_encoding`, `c_string_type` deprecation paths
+   - `embedsignature`, `binding` interaction with introspection
+
+4. **Python 3.14+ specifics**:
+   - **t-strings** (PEP 750) — `Template` type may interact with Cython 3.3+ codegen
+   - **Free-threaded build** — `# cython: freethreading_compatible=True` directive
+   - **`sys.monitoring`** — replaces `sys.settrace` for some use cases (uvloop doesn't use either)
+   - **Immortal singletons** — refcount no longer changes for `None`/`True`/`False`/`Ellipsis`; usually transparent to Cython, but hand-written `Py_INCREF` on these is a no-op
+
+5. **pythoncapi-compat opportunity assessment** — typically LOW for Cython projects because Cython's runtime already abstracts most version differences. Only worth adopting if `includes/compat.h` has many `PY_VERSION_HEX` guards (uvloop has 1 — not worth the dependency).
+
+Tag findings:
+- **CONSIDER** for dead guards and migration cleanup
+- **POLICY** for private-API reimplementations and Cython upper-bound discussions
+- **FIX** rare; only if a deprecated API would actually break on a supported Python version
+
+If nothing substantive: "Cython mode: hand-written C is clean; Cython is bounded `<4`; no Python 3.14 issues."
+
 ## Key Concepts
 
 Python's C API changes across versions:

--- a/plugins/cext-review-toolkit/commands/explore.md
+++ b/plugins/cext-review-toolkit/commands/explore.md
@@ -69,27 +69,32 @@ If no C extension source files are found, inform the user and suggest checking t
 
 ### Code Generation Strategy
 
-When `code_generation` is `"cython"` or `"mypyc"`, adapt the agent dispatch:
+When `code_generation` is `"cython"` or `"mypyc"`, adapt the agent dispatch. The strategy is calibrated against a comprehensive uvloop review (see `reports/uvloop_v3/final_report.md`) where every "skipped" agent was evaluated with one naive pass to verify the skip default produces no FIX-class loss.
 
-**Skip these agents** (95-100% false positive rate on generated code):
-- refcount-auditor (Cython/mypyc manage refcounts)
-- error-path-analyzer (generated error handling is mechanical)
-- null-safety-scanner (generated NULL checks use different patterns)
-- module-state-checker (answers are always "generator limitation")
-- stable-abi-checker (generated code doesn't target stable ABI)
-- version-compat-scanner (generated code handles version compat at the generator level)
+**Always run on Cython** (FIX-class output, real bugs caught):
+- **type-slot-checker** — near-zero FP; finds real bugs in dealloc, partial-init paths, INCREF ordering, `@cython.no_gc_clear` pair breaks. (uvloop: 1 FIX HIGH `_UDPSendContext.new`; 4 CONSIDER on SSLProtocol pair, raise-in-dealloc, UVRequest pin)
+- **gil-discipline-checker** — finds non-atomic FT-counter holdouts, fork-handler globals, freelist races. (uvloop: 4 CONSIDER on FT-readiness gaps)
+- **resource-lifecycle-checker** — finds libuv handle leaks, partial-init cleanup gaps, FD-window leaks. (uvloop: 2 FIX HIGH on `Loop.__dealloc__`, `_StreamWriteContext.new`; 4 CONSIDER on twin sites)
+- **git-history-analyzer** — finds fix-completeness gaps, regression dates, twin-class fix asymmetry. (uvloop: 1 FIX HIGH on 25-site atomic-counter gap)
+- **parity-checker** — adapted Cython mode reads `.pyi` stubs to find advertised-but-unimplemented APIs. **No other agent reads `.pyi`.** (uvloop: 1 FIX HIGH `sock_recvfrom`/`sock_sendto`/`sock_recvfrom_into` raise NotImplementedError but `.pyi` advertises them; 1 CONSIDER `sendfile`/`sock_sendfile` undocumented gap)
 
-**Keep these agents** (still valuable on generated code):
-- type-slot-checker (near-zero FP, finds real bugs in generated dealloc/traverse)
-- gil-discipline-checker (GIL issues can exist in Cython `nogil` blocks)
-- c-complexity-analyzer (generated code complexity is informational)
-- git-history-analyzer (always valuable — finds bugs via historical patterns)
+**Skip by default on Cython** (95-100% FP rate from generator-emitted patterns; validated zero FIX-class loss):
+- **refcount-auditor** — Cython runtime `__Pyx_INCREF`/`__Pyx_DECREF` are noise. Maintainer-written manual `Py_INCREF`/`Py_DECREF` patterns ARE catchable but type-slot-checker covers them in factory-method audits. (uvloop eval: 0 FIX, 1 CONSIDER overlapping with kept agents)
+- **error-path-analyzer** — generated `goto __PyX_L*_error;` cleanup is mechanical. (uvloop eval: 0 FIX, 1 trivial CONSIDER)
+- **null-safety-scanner** — Cython's `if (unlikely(!__pyx_v_X))` patterns are mechanical. (uvloop eval: 0 FIX, 1 LOW CONSIDER)
+- **pyerr-clear-auditor** — Cython runtime `PyErr_Clear` calls are noise; maintainer-written ones in `.pyx` are rare and other agents catch the analog. (uvloop eval: 0 findings)
+
+**Run on Cython for deep-effort reviews** (low FIX yield but unique CONSIDER/POLICY surface):
+- **module-state-checker** — finds `static PyObject*` cached imports outside module state, module-level `cdef` C globals, subinterpreter blockers. Skip default works for FIX-only reviews; deep reviews benefit. (uvloop eval: 1 CONSIDER `stdlib.pxi` ~100 cached imports; subinterpreter assessment)
+- **c-complexity-analyzer** — adapt to walk `.pyx` indent structure rather than C-level (Cython codegen artifacts inflate C-level metrics). Finds maintainer-visible refactor targets. (uvloop eval: 3 CONSIDER on `Loop.create_server`, `__convert_pyaddr_to_sockaddr`, `Loop.create_connection`)
+- **version-compat-scanner** — Cython 4 readiness, deprecated directives, dead `PY_VERSION_HEX` guards in hand-written `includes/*.h`, private-API `_Py_*` reimplementations. (uvloop eval: 1 CONSIDER dead guard, 1 POLICY `_Py_RestoreSignals` reimplementation)
+- **stable-abi-checker** — distinguish maintainer abi3 claim from Cython runtime opt-in (`cython_limited_api=True`); audit hand-written C for non-stable macros; produce feasibility assessment. (uvloop eval: 1 POLICY abi3 not feasible due to libuv coupling)
 
 **For `"pybind11"`**: Run all agents normally (pybind11 code is closer to hand-written).
 
 **For `"mixed"`**: Run all agents but note in the prompt which files are generated so agents can adjust their triage expectations.
 
-Tell agents what code generation tool is in use so they can calibrate their confidence levels and focus on patterns specific to that generator.
+When dispatching kept agents on a Cython project, **tell each agent the code-generation tool, point to `reports/<extension>_v?/preflight/generated_code_map.md` if it exists, and ask them to apply Cython-mode triage** (the agent prompts have a "Cython-mode" section documenting what survives the generator filter). For deep-effort reviews, also pass the `cython_kept_agents.md` playbook reference if available.
 
 ### Phase 0.5: External Tool Baseline (Optional)
 

--- a/plugins/cext-review-toolkit/scripts/discover_extension.py
+++ b/plugins/cext-review-toolkit/scripts/discover_extension.py
@@ -78,8 +78,8 @@ def _detect_setup_py(root: Path) -> list[dict] | None:
     # Pattern: Extension("name", sources=[...])  or  Extension("name", [...])
     ext_pattern = re.compile(
         r'Extension\s*\(\s*["\']([^"\']+)["\']\s*,\s*'
-        r'(?:sources\s*=\s*)?'
-        r'\[([^\]]*)\]',
+        r"(?:sources\s*=\s*)?"
+        r"\[([^\]]*)\]",
         re.DOTALL,
     )
     for m in ext_pattern.finditer(content):
@@ -87,11 +87,13 @@ def _detect_setup_py(root: Path) -> list[dict] | None:
         sources_text = m.group(2)
         # Extract quoted filenames.
         source_files = re.findall(r'["\']([^"\']+)["\']', sources_text)
-        extensions.append({
-            "module_name": mod_name,
-            "source_files": source_files,
-            "detection_method": "setup_py",
-        })
+        extensions.append(
+            {
+                "module_name": mod_name,
+                "source_files": source_files,
+                "detection_method": "setup_py",
+            }
+        )
 
     return extensions if extensions else None
 
@@ -113,23 +115,25 @@ def _detect_pyproject_toml(root: Path) -> list[dict] | None:
     if "tool.setuptools.ext-modules" in content or "ext-modules" in content:
         # Parse ext-modules entries: [[tool.setuptools.ext-modules]]
         ext_pattern = re.compile(
-            r'\[\[tool\.setuptools\.ext-modules\]\]\s*\n(.*?)(?=\n\[|\Z)',
+            r"\[\[tool\.setuptools\.ext-modules\]\]\s*\n(.*?)(?=\n\[|\Z)",
             re.DOTALL,
         )
         for m in ext_pattern.finditer(content):
             block = m.group(1)
             name_m = re.search(r'name\s*=\s*"([^"]+)"', block)
-            sources_m = re.search(r'sources\s*=\s*\[([^\]]*)\]', block)
+            sources_m = re.search(r"sources\s*=\s*\[([^\]]*)\]", block)
             if name_m:
                 mod_name = name_m.group(1)
                 source_files = []
                 if sources_m:
                     source_files = re.findall(r'"([^"]+)"', sources_m.group(1))
-                extensions.append({
-                    "module_name": mod_name,
-                    "source_files": source_files,
-                    "detection_method": "pyproject_toml",
-                })
+                extensions.append(
+                    {
+                        "module_name": mod_name,
+                        "source_files": source_files,
+                        "detection_method": "pyproject_toml",
+                    }
+                )
 
     # Check for meson-python
     if "tool.meson-python" in content or "meson-python" in content:
@@ -173,11 +177,13 @@ def _detect_meson_build(root: Path) -> list[dict] | None:
         mod_name = m.group(1)
         sources_text = m.group(2)
         source_files = re.findall(r"'([^']+)'", sources_text)
-        extensions.append({
-            "module_name": mod_name,
-            "source_files": source_files,
-            "detection_method": "meson_build",
-        })
+        extensions.append(
+            {
+                "module_name": mod_name,
+                "source_files": source_files,
+                "detection_method": "meson_build",
+            }
+        )
 
     return extensions if extensions else None
 
@@ -201,7 +207,7 @@ def _detect_cmake(root: Path) -> list[dict] | None:
         (r"Python3_add_library", "cmake_python3"),
     ]:
         pat = re.compile(
-            pattern_name + r'\s*\(\s*(\w+)\s+(.*?)\)',
+            pattern_name + r"\s*\(\s*(\w+)\s+(.*?)\)",
             re.DOTALL,
         )
         for m in pat.finditer(content):
@@ -210,14 +216,15 @@ def _detect_cmake(root: Path) -> list[dict] | None:
             # Sources are whitespace-separated, skip keywords like MODULE/SHARED.
             tokens = sources_text.split()
             source_files = [
-                t for t in tokens
-                if t.endswith((".c", ".cpp", ".cxx", ".cc"))
+                t for t in tokens if t.endswith((".c", ".cpp", ".cxx", ".cc"))
             ]
-            extensions.append({
-                "module_name": mod_name,
-                "source_files": source_files,
-                "detection_method": method,
-            })
+            extensions.append(
+                {
+                    "module_name": mod_name,
+                    "source_files": source_files,
+                    "detection_method": method,
+                }
+            )
 
     return extensions if extensions else None
 
@@ -252,7 +259,7 @@ def _detect_python_h_fallback(root: Path) -> list[dict] | None:
                 content = f.read_text(encoding="utf-8", errors="replace")
             except OSError:
                 continue
-            m = re.search(r'PyMODINIT_FUNC\s+PyInit_(\w+)', content)
+            m = re.search(r"PyMODINIT_FUNC\s+PyInit_(\w+)", content)
             if m:
                 mod_name = m.group(1)
                 break
@@ -264,11 +271,13 @@ def _detect_python_h_fallback(root: Path) -> list[dict] | None:
             except ValueError:
                 rel_files.append(str(f))
 
-        extensions.append({
-            "module_name": mod_name,
-            "source_files": rel_files,
-            "detection_method": "python_h_include",
-        })
+        extensions.append(
+            {
+                "module_name": mod_name,
+                "source_files": rel_files,
+                "detection_method": "python_h_include",
+            }
+        )
 
     return extensions
 
@@ -284,7 +293,7 @@ def _scan_init_functions(root: Path, c_files: list[str]) -> dict[str, str]:
             content = full_path.read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
-        m = re.search(r'PyMODINIT_FUNC\s+PyInit_(\w+)', content)
+        m = re.search(r"PyMODINIT_FUNC\s+PyInit_(\w+)", content)
         if m:
             init_funcs[rel_path] = f"PyInit_{m.group(1)}"
     return init_funcs
@@ -300,7 +309,7 @@ def _scan_limited_api(root: Path, c_files: list[str]) -> tuple[bool, str | None]
             content = full_path.read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
-        m = re.search(r'#\s*define\s+Py_LIMITED_API\s+(0x[0-9A-Fa-f]+|\w+)?', content)
+        m = re.search(r"#\s*define\s+Py_LIMITED_API\s+(0x[0-9A-Fa-f]+|\w+)?", content)
         if m:
             version_val = m.group(1) if m.group(1) else None
             return True, version_val
@@ -389,9 +398,9 @@ def _detect_code_generation(root: Path, c_files: list[str]) -> str:
             except OSError:
                 has_hand_written = True
                 continue
-            if re.search(r'\bCPyDef_\w+|\bCPyStatic_\w+|\bCPyModule_\w+', content):
+            if re.search(r"\bCPyDef_\w+|\bCPyStatic_\w+|\bCPyModule_\w+", content):
                 has_mypyc = True
-            elif re.search(r'PYBIND11_MODULE\s*\(|py::class_', content):
+            elif re.search(r"PYBIND11_MODULE\s*\(|py::class_", content):
                 has_pybind11 = True
             else:
                 has_hand_written = True
@@ -448,8 +457,7 @@ def discover(target: str) -> dict:
                 source_paths.append(full)
                 all_c_files.add(sf)
         ext["header_files"] = [
-            str(h.relative_to(root))
-            for h in _find_h_files(root, source_paths)
+            str(h.relative_to(root)) for h in _find_h_files(root, source_paths)
         ]
 
     all_c_files_list = sorted(all_c_files)
@@ -466,6 +474,18 @@ def discover(target: str) -> dict:
     # Detect code generation tool.
     code_generation = _detect_code_generation(root, all_c_files_list)
 
+    # Detect type stubs (.pyi files). Their presence signals that parity-checker
+    # should use its Cython-mode `.pyi` ↔ `.pyx` method-set parity scope.
+    pyi_files = sorted(
+        str(p.relative_to(root))
+        for p in root.rglob("*.pyi")
+        if not any(
+            part.startswith(".")
+            or part in {"build", "dist", "__pycache__", "site-packages"}
+            for part in p.relative_to(root).parts
+        )
+    )
+
     return {
         "project_root": str(root),
         "scan_root": str(target_path),
@@ -477,6 +497,7 @@ def discover(target: str) -> dict:
         "total_c_files": total_c_files,
         "total_lines": total_lines,
         "code_generation": code_generation,
+        "type_stubs": pyi_files,
     }
 
 

--- a/tests/test_discover_extension.py
+++ b/tests/test_discover_extension.py
@@ -16,7 +16,9 @@ class TestDiscoverExtension(unittest.TestCase):
             sources='["src/myext.c"]',
             python_requires=">=3.9",
         )
-        with TempExtension({"src/myext.c": MINIMAL_EXTENSION}, setup_py=setup_py) as root:
+        with TempExtension(
+            {"src/myext.c": MINIMAL_EXTENSION}, setup_py=setup_py
+        ) as root:
             result = discover.discover(str(root))
             self.assertGreaterEqual(len(result["extensions"]), 1)
             ext = result["extensions"][0]
@@ -42,7 +44,7 @@ class TestDiscoverExtension(unittest.TestCase):
 
     def test_detect_limited_api(self):
         """Py_LIMITED_API define detected."""
-        code = '#define Py_LIMITED_API 0x030A0000\n' + MINIMAL_EXTENSION
+        code = "#define Py_LIMITED_API 0x030A0000\n" + MINIMAL_EXTENSION
         with TempExtension({"myext.c": code}) as root:
             result = discover.discover(str(root))
             self.assertTrue(result["limited_api"])
@@ -67,10 +69,14 @@ setup(
     ],
 )
 """
-        code_a = '#include <Python.h>\nPyMODINIT_FUNC PyInit_ext_a(void) { return NULL; }\n'
-        code_b = '#include <Python.h>\nPyMODINIT_FUNC PyInit_ext_b(void) { return NULL; }\n'
+        code_a = (
+            "#include <Python.h>\nPyMODINIT_FUNC PyInit_ext_a(void) { return NULL; }\n"
+        )
+        code_b = (
+            "#include <Python.h>\nPyMODINIT_FUNC PyInit_ext_b(void) { return NULL; }\n"
+        )
         with TempExtension(
-            {"a.c": code_a, "b.c": code_b, "b_util.c": '#include <Python.h>\n'},
+            {"a.c": code_a, "b.c": code_b, "b_util.c": "#include <Python.h>\n"},
             setup_py=setup_py,
         ) as root:
             result = discover.discover(str(root))
@@ -108,7 +114,7 @@ py.extension_module('myext', ['myext.c', 'util.c'])
 """
         files = {
             "myext.c": MINIMAL_EXTENSION,
-            "util.c": '#include <Python.h>\n',
+            "util.c": "#include <Python.h>\n",
             "meson.build": meson_content,
         }
         with TempExtension(files) as root:
@@ -131,13 +137,50 @@ py.extension_module('myext', ['myext.c', 'util.c'])
 
     def test_total_c_files_count(self):
         """total_c_files counts all .c files found."""
-        with TempExtension({
-            "a.c": '#include <Python.h>\n',
-            "b.c": '#include <Python.h>\n',
-            "lib/c.c": '#include <Python.h>\n',
-        }) as root:
+        with TempExtension(
+            {
+                "a.c": "#include <Python.h>\n",
+                "b.c": "#include <Python.h>\n",
+                "lib/c.c": "#include <Python.h>\n",
+            }
+        ) as root:
             result = discover.discover(str(root))
             self.assertEqual(result["total_c_files"], 3)
+
+    def test_type_stubs_detected(self):
+        """type_stubs lists .pyi files for parity-checker Cython mode."""
+        with TempExtension(
+            {
+                "myext.c": "#include <Python.h>\n",
+                "myext.pyi": "def foo() -> int: ...\n",
+                "subpkg/other.pyi": "def bar() -> str: ...\n",
+            }
+        ) as root:
+            result = discover.discover(str(root))
+            self.assertIn("type_stubs", result)
+            self.assertEqual(
+                sorted(result["type_stubs"]),
+                ["myext.pyi", "subpkg/other.pyi"],
+            )
+
+    def test_type_stubs_empty_when_none(self):
+        """type_stubs is an empty list when no .pyi files exist."""
+        with TempExtension({"myext.c": "#include <Python.h>\n"}) as root:
+            result = discover.discover(str(root))
+            self.assertEqual(result["type_stubs"], [])
+
+    def test_type_stubs_skips_build_dirs(self):
+        """type_stubs ignores .pyi files inside build/dist/__pycache__."""
+        with TempExtension(
+            {
+                "real.pyi": "x: int\n",
+                "build/generated.pyi": "y: int\n",
+                "dist/old.pyi": "z: int\n",
+                "__pycache__/cached.pyi": "w: int\n",
+            }
+        ) as root:
+            result = discover.discover(str(root))
+            self.assertEqual(result["type_stubs"], ["real.pyi"])
 
 
 class TestCodeGenerationDetection(unittest.TestCase):
@@ -157,7 +200,9 @@ class TestCodeGenerationDetection(unittest.TestCase):
 PyMODINIT_FUNC PyInit_myext(void) { return NULL; }
 """
         setup_py = SETUP_PY_TEMPLATE.format(
-            name="myext", sources='["myext.c"]', python_requires=">=3.9",
+            name="myext",
+            sources='["myext.c"]',
+            python_requires=">=3.9",
         )
         with TempExtension({"myext.c": cython_code}, setup_py=setup_py) as root:
             result = discover.discover(str(root))
@@ -166,7 +211,9 @@ PyMODINIT_FUNC PyInit_myext(void) { return NULL; }
     def test_cython_detection_from_pyx(self):
         """Cython detected from .pyx file presence."""
         setup_py = SETUP_PY_TEMPLATE.format(
-            name="myext", sources='["myext.c"]', python_requires=">=3.9",
+            name="myext",
+            sources='["myext.c"]',
+            python_requires=">=3.9",
         )
         with TempExtension(
             {"myext.c": MINIMAL_EXTENSION, "myext.pyx": "# cython source"},
@@ -185,7 +232,9 @@ PyObject *CPyDef_my_function(void) { return NULL; }
 PyMODINIT_FUNC PyInit_myext(void) { return NULL; }
 """
         setup_py = SETUP_PY_TEMPLATE.format(
-            name="myext", sources='["myext.c"]', python_requires=">=3.9",
+            name="myext",
+            sources='["myext.c"]',
+            python_requires=">=3.9",
         )
         with TempExtension({"myext.c": mypyc_code}, setup_py=setup_py) as root:
             result = discover.discover(str(root))
@@ -201,7 +250,9 @@ PYBIND11_MODULE(myext, m) {
 }
 """
         setup_py = SETUP_PY_TEMPLATE.format(
-            name="myext", sources='["myext.cpp"]', python_requires=">=3.9",
+            name="myext",
+            sources='["myext.cpp"]',
+            python_requires=">=3.9",
         )
         with TempExtension({"myext.cpp": pybind_code}, setup_py=setup_py) as root:
             result = discover.discover(str(root))


### PR DESCRIPTION
## Summary
- Calibrated the Cython skip-strategy in `commands/explore.md` against a comprehensive uvloop 0.22.1 review (`reports/uvloop_v3/`) where every skipped agent was evaluated with one naive pass.
- **`parity-checker` moved OUT of the Cython skip list** — its `.pyi`-vs-`.pyx` adapted-scope check finds bugs no other agent in the toolkit can find (uvloop: 1 FIX HIGH, 1 CONSIDER).
- Four other agents moved to a new "deep-effort tier" — skip by default for FIX-only review, but produce real CONSIDER/POLICY findings when invoked on Cython projects (subinterpreter blockers, `.pyx`-source-level complexity refactors, dead version guards, abi3 feasibility assessment).
- Added Cython-mode sections to 5 agent prompts documenting what each can uniquely find on Cython projects, with uvloop 0.22.1 reference findings as calibration anchors.
- `discover_extension.py` now emits a `type_stubs` field listing `.pyi` files — the signal parity-checker uses to engage Cython mode.

## Skip-strategy data (uvloop eval pass)

| Agent | Verdict | Net-new findings |
|---|---|---|
| parity-checker | **SKIP DISPROVEN** | 1 FIX HIGH, 1 CONSIDER (folded as Findings 9 & 28) |
| error-path-analyzer | Skip validated | 0 FIX |
| null-safety-scanner | Skip validated | 0 FIX |
| pyerr-clear-auditor | Skip validated | 0 |
| refcount-auditor | Skip validated for FIX | 0 FIX, 1 CONSIDER overlap |
| module-state-checker | Deep-effort tier | 1 CONSIDER (cached imports) |
| c-complexity-analyzer | Deep-effort tier | 3 CONSIDER (refactor targets) |
| version-compat-scanner | Deep-effort tier | 1 CONSIDER + 1 POLICY |
| stable-abi-checker | Deep-effort tier | 1 POLICY (abi3 feasibility) |

## Test plan
- [x] All existing 271 tests pass
- [x] 3 new tests for `type_stubs` field in `test_discover_extension.py` (total 274)
- [x] `ruff format` + `ruff check` clean on touched files
- [x] Verified `discover_extension.py` correctly detects `uvloop/loop.pyi` on the real project
- [x] Verified `commands/explore.md` Cython section is calibrated against uvloop reference findings
- [ ] Future: validate revised strategy on next Cython review (h3-py is in queue with `.pyi` stubs)

## Deliverables for users
- `/plugin update cext-review-toolkit` after merge will pick up the new agent prompts.
- Next deep-effort `/cext-review-toolkit:explore` on a Cython project will dispatch parity-checker by default and can opt-in to module-state/complexity/version-compat/stable-abi for the deep-effort tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)