### PR TITLE
docs: add WORKING_WITH_MAINTAINERS.md and revamp README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Documentation
+- **`WORKING_WITH_MAINTAINERS.md`** (new, top-level) — communication norms for using the toolkit on projects you don't maintain. Covers the ask-don't-dump principle, before-you-run and before-you-share checklists, outreach templates, severity-translation guidance (FIX/CONSIDER/POLICY vs how maintainers actually read those tags), security disclosure, the umbrella-vs-many-issues decision, anti-patterns (auto-filing, name-and-shame threads, social-media-without-consent), and three working examples (ijson, h5py, uvloop). The document is referenced from a prominent ⚠️ callout at the top of `README.md` and from the synthesis section of `plugins/cext-review-toolkit/commands/explore.md`.
+- **`README.md` revamp** — adds the maintainer-communication callout near the top; brings the agent count current (was 10, actually 13 audit agents plus the phase-0 generated-code-mapper specialist); adds the missing `parity-checker`, `pyerr-clear-auditor`, `resource-lifecycle-checker`, `generated-code-mapper` to the agent inventory; documents the 2-naive + 1-informed methodology that has been standard practice for some time; documents the optional reproducer pass (7-tier dispatch); adds a cost-and-time-expectations section; updates the Explore Command Phases table to include the mapper preflight (Phase 0) and reproducer pass (Phase 8 optional); rewrites the "Reviewing an unfamiliar extension" workflow to start with `WORKING_WITH_MAINTAINERS.md` and separate "extension you don't own" from "extension you maintain"; clarifies that `POLICY` items are the maintainer's call, not yours; adds Cython + C++ language coverage and the optional tree-sitter-cython + libfiu prerequisites; refreshes the sibling-projects comparison.
+- **`plugins/cext-review-toolkit/commands/explore.md`** — adds a before-sharing caveat to the Phase 3 (Synthesis) section reminding users that the synthesis is an internal artifact and that whether/how to share it with the maintainer is a separate human-judgment step.
+
 ## [0.5.0] - 2026-04-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,8 +1,23 @@
 # C Extension Review Toolkit
 
-A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugin for reviewing CPython C extensions -- finding API misuse, memory safety bugs, compatibility issues, and correctness problems specific to code that *consumes* the Python/C API.
+A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugin for reviewing CPython C extensions — finding API misuse, memory safety bugs, compatibility issues, and correctness problems specific to code that *consumes* the Python/C API.
 
-Built for the specific concerns of C extension authors -- reference counting from the caller's perspective, borrowed reference lifetimes, module state management, type slot correctness, stable ABI compliance, and version compatibility -- not general-purpose C analysis.
+Built for the specific concerns of C extension authors — reference counting from the caller's perspective, borrowed-reference lifetimes, module state management, type slot correctness, free-threading readiness, parity between C and Python implementations, stable ABI compliance, and version compatibility — not general-purpose C analysis.
+
+---
+
+## ⚠️ Read this before you use the toolkit on someone else's project
+
+This tool finds bugs in **other people's code**. That code is usually written by someone giving away their work for free. Before running this on a project you don't own:
+
+- **Read [WORKING_WITH_MAINTAINERS.md](WORKING_WITH_MAINTAINERS.md).** It is the most important document in this repository.
+- **Reach out to the maintainer first.** A short, friendly message — *"I'd like to run a static-analysis tool on your project, would the report be useful?"* — takes five minutes and changes everything that follows.
+- **Don't auto-file issues. Don't auto-open PRs.** Every finding should pass through human triage before reaching the maintainer.
+- **Security findings need responsible disclosure**, not a public issue.
+
+A 50-finding report is 50 hours of homework for a maintainer who didn't ask for it. The tool's value depends entirely on whether they want to receive what you produce.
+
+---
 
 ## Why a Separate Tool?
 
@@ -10,11 +25,11 @@ Built for the specific concerns of C extension authors -- reference counting fro
 |---------|-------------------------------------------|----------------------------|
 | **Perspective** | Code that *implements* the C API | Code that *calls* the C API |
 | **Parsing** | Regex (PEP 7 code is regular) | Tree-sitter (extension code varies wildly) |
-| **Top bug class** | Refcount leaks in runtime code | Borrowed refs held across callbacks |
-| **Module state** | N/A (CPython manages its own) | Core concern -- init style, global state |
+| **Top bug class** | Refcount leaks in runtime code | Borrowed refs held across callbacks; UAF in proxy callbacks |
+| **Module state** | N/A (CPython manages its own) | Core concern — init style, global state, sub-interpreter compat |
 | **Type definitions** | Part of the runtime | Must follow slot contracts correctly |
 | **ABI** | Defines the ABI | Must comply with the ABI |
-| **Dependencies** | stdlib only | tree-sitter, tree-sitter-c |
+| **Dependencies** | stdlib only | tree-sitter, tree-sitter-c (optional: tree-sitter-cpp, tree-sitter-cython) |
 
 ## Installation
 
@@ -43,6 +58,10 @@ claude --plugin-dir cext-review-toolkit/plugins/cext-review-toolkit
 - **Claude Code** installed and running
 - **Python 3.10+** for the analysis scripts
 - **tree-sitter** and **tree-sitter-c**: `pip install tree-sitter tree-sitter-c`
+- **tree-sitter-cpp** (optional): `pip install tree-sitter-cpp` — enables C++ file parsing
+- **tree-sitter-cython** (optional, for Cython extensions): `pip install git+https://github.com/devdanzin/tree-sitter-cython.git@fix/grammar-gaps`
+- **clang-tidy** and **cppcheck** (optional): system packages — enables external tool cross-referencing
+- **libfiu** (optional): for OOM-injection reproducers
 
 ## Quick Start
 
@@ -51,64 +70,96 @@ Navigate to a C extension project, then:
 ```bash
 /cext-review-toolkit:health       # Quick health dashboard
 /cext-review-toolkit:hotspots     # Refcount leaks + error bugs + complexity
-/cext-review-toolkit:explore      # Full exploration (all 10 agents)
+/cext-review-toolkit:explore      # Full exploration (mapper preflight + 13 audit agents + reproducer pass)
 /cext-review-toolkit:migrate      # Modernization checklist
 ```
 
-Start with `health` for a quick overview, then `hotspots` to find the highest-impact bugs.
+Start with `health` for a quick overview, then `hotspots` to find the highest-impact bugs. Use `explore` for the full audit pipeline.
+
+### Cost and time expectations
+
+A full `/explore` on a medium extension (~5 KLOC) typically runs:
+
+- **~10-30 minutes** wall-clock for the audit phase
+- **Real money** in Claude API tokens — a thorough multi-pass review can cost anywhere from a few dollars to tens of dollars depending on extension size, agent count, and whether you run the reproducer pass
+- **Significantly more** for large extensions (~25 KLOC+) or when the 2-naive + 1-informed methodology is run end-to-end
+
+This isn't free to run, and it isn't free for the maintainer to receive. Plan accordingly.
 
 ## What's Included
 
-### Agents
+### Agents (13 audit + 1 phase-0 specialist)
 
-#### Safety-Critical (script-backed, Tree-sitter-powered)
+#### Phase-0 specialist
 
-| Agent | What It Finds | Script |
-|-------|--------------|--------|
-| **refcount-auditor** | Leaked refs, borrowed-ref-across-callback, stolen-ref misuse, missing Py_CLEAR | `scan_refcounts.py` |
-| **error-path-analyzer** | Missing NULL checks, exception clobbering, return-without-exception | `scan_error_paths.py` |
-| **null-safety-scanner** | Unchecked allocations, deref-before-check | `scan_null_checks.py` |
-| **gil-discipline-checker** | GIL released during Python API, blocking I/O with GIL, callback GIL issues, free-threading readiness | `scan_gil_usage.py` |
-
-#### Extension-Specific (script-backed, Tree-sitter-powered)
-
-| Agent | What It Finds | Script |
-|-------|--------------|--------|
-| **module-state-checker** | Legacy single-phase init, global PyObject* state, missing m_traverse/m_clear, static types | `scan_module_state.py` |
-| **type-slot-checker** | Missing tp_free, traverse gaps, wrong Py_NotImplemented handling, heap type issues | `scan_type_slots.py` |
-
-#### Compatibility (qualitative)
-
-| Agent | What It Finds |
+| Agent | What It Does |
 |-------|--------------|
-| **stable-abi-checker** | Internal struct access, private API calls, limited API violations |
-| **version-compat-scanner** | API calls without version guards, dead compatibility code, deprecated APIs |
+| **generated-code-mapper** | Detects code generators (Cython, pybind11, nanobind, custom) and produces a per-file orientation guide (`generated_code_map.md`) that downstream agents read. Mandatory first step on every review. |
 
-#### Code Quality and History
+#### Safety-critical (script-backed, Tree-sitter-powered)
 
 | Agent | What It Finds | Script |
 |-------|--------------|--------|
-| **c-complexity-analyzer** | Functions scored by complexity, nesting, line count | `measure_c_complexity.py` |
-| **git-history-analyzer** | Similar bugs elsewhere, churn-based risk prioritization | `analyze_history.py` |
+| **refcount-auditor** | Leaked refs, borrowed-ref-across-callback, stolen-ref misuse, missing Py_CLEAR, UAF in proxy callbacks | `scan_refcounts.py` |
+| **error-path-analyzer** | Missing NULL checks, exception clobbering, return-without-exception, error-buffer races | `scan_error_paths.py` |
+| **null-safety-scanner** | Unchecked allocations, deref-before-check, user-driven state-machine NULL | `scan_null_checks.py` |
+| **gil-discipline-checker** | GIL released during Python API, blocking I/O with GIL, callback GIL issues, free-threading readiness | `scan_gil_usage.py` |
+| **resource-lifecycle-checker** | Non-PyObject resource pairs, talloc lifetime, libuv handle leaks, FD-window leaks, buffer protocol | `scan_resource_lifecycle.py` |
+
+#### Extension-specific (script-backed, Tree-sitter-powered)
+
+| Agent | What It Finds | Script |
+|-------|--------------|--------|
+| **module-state-checker** | Legacy single-phase init, global PyObject* state, missing m_traverse/m_clear, static types, sub-interpreter readiness | `scan_module_state.py` |
+| **type-slot-checker** | Missing tp_free, traverse gaps, GC-flag inconsistency, re-init leak, heap type issues | `scan_type_slots.py` |
+| **pyerr-clear-auditor** | Silent MemoryError/KeyboardInterrupt swallowing, error-rewrite without `PyErr_ExceptionMatches` | `scan_pyerr_clear.py` |
+
+#### Compatibility and parity
+
+| Agent | What It Finds | Script |
+|-------|--------------|--------|
+| **stable-abi-checker** | Internal struct access, private API calls, limited API violations, abi3 feasibility | (qualitative + `data/stable_abi.json`) |
+| **version-compat-scanner** | API calls without version guards, dead compatibility code, deprecated APIs, `pythoncapi-compat` opportunities | `scan_version_compat.py` |
+| **parity-checker** | Behavioral differences between C and Python implementations of the same functionality; for Cython, `.pyi` ↔ `.pyx` adapted-scope checks | (qualitative) |
+
+#### Code quality and history
+
+| Agent | What It Finds | Script |
+|-------|--------------|--------|
+| **c-complexity-analyzer** | Functions scored by complexity, nesting, line count; cross-referenced with safety findings | `measure_c_complexity.py` |
+| **git-history-analyzer** | Similar bugs elsewhere, churn-based risk prioritization, fix-completeness gaps | `analyze_history.py` |
 
 ### Commands
 
 | Command | Purpose | Agents Used |
 |---------|---------|-------------|
-| `explore` | Full analysis with selectable aspects | All (configurable) |
+| `explore` | Full analysis with selectable aspects, mapper preflight, optional reproducer pass | All (configurable) |
 | `health` | Quick scored dashboard | All in summary mode |
 | `hotspots` | Find worst functions to fix first | refcount + errors + complexity |
 | `migrate` | Modernization checklist | module-state + type-slots + abi + compat |
 
 ## How It Works
 
+### The 2-naive + 1-informed methodology
+
+The standard practice for thorough reviews is:
+
+1. **Phase 0 — Discovery + mapper preflight.** The generated-code-mapper runs first, producing a per-file orientation guide that downstream agents read. External tools (clang-tidy + cppcheck) baseline if available.
+2. **R1 — Naive pass 1.** All relevant audit agents dispatched in parallel; each agent reads the mapper preflight, runs its scanner, and triages findings independently.
+3. **R2 — Naive pass 2 (independent).** Same agents re-dispatched without R1's findings as context. When R1 and R2 independently flag the same site, that site is highly confirmed.
+4. **R3 — Informed-rerun.** Agents dispatched with a synthesized briefing summarizing R1+R2 convergences. Instructed to NOT re-flag confirmed bugs but to hunt for adjacent code, twin-class divergence, and missed paths. Typically adds 5-10 net-new findings R1+R2 missed.
+5. **Synthesis.** Builds a convergence matrix across R1/R2/R3 + external tools. Resolves tensions, classifies severity, writes the consolidated report.
+6. **Reproducer pass (optional).** Categorizes every FIX/CONSIDER finding into one of 7 tiers (public-API SEGV, libfiu OOM injection, refcount/RSS leak, async/sync I/O, TSan FT race, hand-written, source-only) and dispatches a reproducer agent per tier in parallel. Each reproducer is subprocess-isolated and produces a verifiable artifact.
+
 ### Tree-sitter Parsing
 
 Unlike cpython-review-toolkit (regex-based), this toolkit uses Tree-sitter for C parsing. This enables analysis that regex fundamentally cannot do:
 
-- **Borrowed reference lifetime tracking**: Detect when a borrowed ref survives across a call back into Python -- the #1 extension-specific bug pattern
-- **Type slot cross-referencing**: Connect a PyTypeObject/PyType_Spec to its struct definition and slot function implementations
-- **Accurate scope analysis**: Distinguish file-scope static variables from local ones, track variable assignments within functions
+- **Borrowed reference lifetime tracking**: detect when a borrowed ref survives across a call back into Python — the #1 extension-specific bug pattern
+- **Type slot cross-referencing**: connect a `PyTypeObject` / `PyType_Spec` to its struct definition and slot function implementations
+- **Accurate scope analysis**: distinguish file-scope static variables from local ones, track variable assignments within functions
+
+For Cython projects, an additional `tree-sitter-cython` parser layer powers five `.pyx`-aware scanners (silent-noexcept, buffer protocol, PyCapsule, cinit/init reinit-leak, nogil-touches-Python).
 
 ### Extension Discovery
 
@@ -125,27 +176,38 @@ Every finding is tagged:
 
 | Tag | Meaning | Example |
 |-----|---------|---------|
-| **FIX** | Bug causing crashes, leaks, or wrong behavior | Borrowed ref across callback, missing DECREF |
-| **CONSIDER** | Likely improvement, may have migration cost | Single-phase init, missing Py_TPFLAGS_BASETYPE |
-| **POLICY** | Design decision for the maintainer | Whether to adopt stable ABI, drop old Python versions |
+| **FIX** | Bug causing crashes, leaks, or wrong behavior | Borrowed ref across callback, missing DECREF, NDEBUG-stripped assertion masking NULL |
+| **CONSIDER** | Likely improvement, may have migration cost | Single-phase init, missing Py_TPFLAGS_BASETYPE, missing GC support |
+| **POLICY** | Design decision for the maintainer — *their call, not yours* | Whether to adopt stable ABI, drop old Python versions, multi-phase init |
 | **ACCEPTABLE** | Noted but no action needed | Intentional global state for singleton module |
+
+`POLICY` items are not "things you should push the maintainer to fix"; they're things that need *the maintainer's* judgment. See [WORKING_WITH_MAINTAINERS.md](WORKING_WITH_MAINTAINERS.md) for severity-translation guidance.
 
 ### External Tool Integration (Optional)
 
 If available, the toolkit can use:
 - **clang-tidy** with `compile_commands.json` for deeper data-flow analysis
-- **cppcheck** for buffer overflow and uninitialized variable detection
+- **cppcheck** for buffer overflow and uninitialized variable detection (no `compile_commands.json` required, but its output is more useful with one)
 
-These are never required -- the Tree-sitter-based analysis is the baseline.
+These are never required — the Tree-sitter-based analysis is the baseline.
 
 ## Recommended Workflows
 
-### Reviewing an unfamiliar extension
+### Reviewing an unfamiliar extension you don't own
+
+1. **First, read [WORKING_WITH_MAINTAINERS.md](WORKING_WITH_MAINTAINERS.md).**
+2. Skim recent commits, open issues, and `CONTRIBUTING.md` / `SECURITY.md`.
+3. `/cext-review-toolkit:health` — quick overview.
+4. `/cext-review-toolkit:hotspots` — where are the bugs?
+5. Decide whether the maintainer would benefit from a deeper review. If yes, **reach out before going further**.
+6. With agreement: `/cext-review-toolkit:explore . refcounts errors deep` for a focused safety pass, or the full `/explore` pipeline.
+
+### Reviewing your own extension
 
 ```
-1. /cext-review-toolkit:health              -> Quick overview
-2. /cext-review-toolkit:hotspots            -> Where are the bugs?
-3. /cext-review-toolkit:explore . refcounts errors deep  -> Deep dive on safety
+1. /cext-review-toolkit:explore . all deep    -> Full analysis
+2. Focus on FIX findings; reproduce the highest-impact ones first
+3. Re-run on specific files after fixes
 ```
 
 ### Preparing for a Python version upgrade
@@ -155,57 +217,64 @@ These are never required -- the Tree-sitter-based analysis is the baseline.
 2. /cext-review-toolkit:migrate               -> Full migration checklist
 ```
 
-### Modernizing an extension
+### Modernizing an extension you maintain
 
 ```
 1. /cext-review-toolkit:migrate               -> What to modernize
 2. /cext-review-toolkit:explore . module-state type-slots deep  -> Detailed guidance
 ```
 
-### Pre-release safety audit
-
-```
-1. /cext-review-toolkit:explore . all deep    -> Full analysis
-2. Focus on FIX findings
-3. Re-run on specific files after fixes
-```
-
 ## Explore Command Phases
 
 | Phase | Agents | Purpose |
 |-------|--------|---------|
-| **0** | Extension discovery | Detect layout, source files, Python targets |
-| **1** | (git history noted) | Temporal context available for Phase 2F |
-| **2A** | refcount-auditor, error-path-analyzer | Safety-critical (highest value) |
-| **2B** | null-safety-scanner, gil-discipline-checker | Memory safety |
-| **2C** | module-state-checker, type-slot-checker | Extension correctness |
-| **2D** | stable-abi-checker, version-compat-scanner | Compatibility |
-| **2E** | c-complexity-analyzer | Code quality |
-| **2F** | git-history-analyzer | Similar bugs, risk prioritization |
-| **3** | Synthesis | Deduplicate, resolve conflicts, produce summary |
+| **0** | Extension discovery, mapper preflight, external tools baseline | Detect layout, source files, generators, codegen idioms; produce orientation guide |
+| **1** | refcount-auditor, error-path-analyzer | Safety-critical (highest value) |
+| **2** | null-safety-scanner, gil-discipline-checker, resource-lifecycle-checker | Memory safety |
+| **3** | module-state-checker, type-slot-checker, pyerr-clear-auditor | Extension correctness |
+| **4** | stable-abi-checker, version-compat-scanner, parity-checker | Compatibility and parity |
+| **5** | c-complexity-analyzer | Code quality |
+| **6** | git-history-analyzer | Similar bugs, risk prioritization, fix-completeness review |
+| **7** | Synthesis | Deduplicate, resolve conflicts, produce consolidated report |
+| **8** *(optional)* | Reproducer pass | 7-tier dispatch: public-API SEGV, libfiu OOM, refcount/RSS, async/sync I/O, TSan FT race, hand-written, source-only |
+
+For thorough reviews, run R1 → R2 → R3 (the 2-naive + 1-informed methodology) before synthesis.
 
 ## Limitations
 
 - **Tree-sitter, not a compiler**: Cannot resolve macros, follow pointer aliasing, or track through complex preprocessor conditionals. Reports candidates with expected 20-40% false positive rate; agents confirm or dismiss each finding.
-- **Single-file scope for scripts**: Scripts analyze each function independently. Cross-function reference ownership transfer is tracked only at the API boundary level.
-- **External tools are optional**: Without `compile_commands.json`, no clang-tidy or cppcheck integration. The Tree-sitter analysis is comprehensive but has inherent limits.
-- **Struct-to-type matching is heuristic**: Connecting a PyTypeObject to its backing struct uses name matching and `tp_basicsize` analysis. Unusual naming or indirection may cause mismatches.
+- **Single-file scope for scripts**: Scripts analyze each function independently. Cross-function reference ownership transfer is tracked only at the API boundary level. Cross-TU analysis is the agent's job, not the script's.
+- **External tools are optional**: Without `compile_commands.json`, no clang-tidy. cppcheck still runs but with less data-flow precision.
+- **Struct-to-type matching is heuristic**: Connecting a `PyTypeObject` to its backing struct uses name matching and `tp_basicsize` analysis. Unusual naming or indirection may cause mismatches.
+- **The tool's confidence is not a substitute for your triage.** Even FIX findings need human review before being shared with a maintainer.
+
+## Documentation
+
+| File | Purpose |
+|------|---------|
+| **[WORKING_WITH_MAINTAINERS.md](WORKING_WITH_MAINTAINERS.md)** | **How to use what this tool produces in a way that helps maintainers rather than burdens them. Read first if you're using this on someone else's project.** |
+| [docs/reproducer-techniques.md](docs/reproducer-techniques.md) | Catalogue of reproducer techniques (29 numbered patterns) |
+| [cext-review-toolkit-design.md](cext-review-toolkit-design.md) | Design document — architecture, scripts, agents, classification |
 
 ## Comparison with Sibling Projects
 
 | Dimension | code-review-toolkit | cpython-review-toolkit | cext-review-toolkit |
 |-----------|--------------------|-----------------------|--------------------|
-| **Language** | Python | C (CPython source) | C (extensions) |
+| **Language** | Python | C (CPython source) | C / C++ / Cython (extensions) |
 | **Parsing** | Python `ast` | Regex | Tree-sitter |
 | **Target** | Python projects | CPython runtime | C extensions |
-| **Agents** | 14 | 10 | 10 |
-| **Scripts** | 8 | 7 | 10 |
-| **Unique value** | Test coverage, architecture | GIL, PEP 7, include graph | Module state, type slots, ABI, migrate |
+| **Audit agents** | 14 | 10 | 13 + 1 phase-0 specialist |
+| **Scripts** | 8 | 7 | 15+ |
+| **Unique value** | Test coverage, architecture | GIL, PEP 7, include graph | Module state, type slots, ABI, parity, FT readiness, reproducer pass |
+
+There's also a sibling **[ft-review-toolkit](https://github.com/devdanzin/ft-review-toolkit)** focused specifically on free-threading analysis (PEP 703 readiness, TSan triage, race classification) that complements this toolkit on FT-relevant reviews.
 
 ## Author
 
-Danzin
+Daniel ([@devdanzin](https://github.com/devdanzin))
 
 ## License
 
-MIT -- see [LICENSE](LICENSE) for details.
+MIT — see [LICENSE](LICENSE) for details.
+
+The MIT license disclaims warranty in the legal sense. The social contract — between the tool's user and the open-source maintainer whose code you're reviewing — is not a legal question. See [WORKING_WITH_MAINTAINERS.md](WORKING_WITH_MAINTAINERS.md).

--- a/WORKING_WITH_MAINTAINERS.md
+++ b/WORKING_WITH_MAINTAINERS.md
@@ -1,0 +1,343 @@
+# Working with maintainers
+
+cext-review-toolkit finds bugs in **other people's code**. That code was written by real people who are
+giving away their work for free. This document is about how to use what the tool produces in a way
+that is genuinely useful to them, not a burden.
+
+It is the most important document in this repository. The tool's value depends entirely on whether
+maintainers want to receive what you send them.
+
+---
+
+## TL;DR — the four rules
+
+1. **Reach out before you file.** A short, friendly message saying *"I ran a static-analysis tool, here's
+   what it found in broad strokes — would the report be useful to you, and if so how would you like to
+   receive it?"* takes 5 minutes and changes everything that follows.
+2. **Treat the report as a homework assignment for the maintainer.** A 50-finding report can be
+   50 hours of work. Their priorities, not yours, decide what gets fixed.
+3. **Don't auto-file issues. Don't auto-open PRs.** This tool can produce a lot of well-formatted
+   output very quickly. Humans should decide what to send and when.
+4. **Security findings need responsible disclosure**, not a public issue. If something looks like a
+   memory-safety bug exploitable by attacker-controlled input, follow the project's `SECURITY.md` (or
+   email the maintainers privately) before doing anything else.
+
+If you only read the TL;DR, that's enough to be a good citizen with this tool. The rest of this
+document is the longer version.
+
+---
+
+## The first principle: ask, don't dump
+
+The most consequential signal in this whole pipeline is whether the maintainer **wants** what you
+generated. Not whether the findings are real. Not whether the report is well-written. Whether they
+want to receive it, in this volume, right now.
+
+Open-source maintainers — especially solo maintainers and small teams — are usually working on this
+in their free time. A polished 80-finding report dropped into their issue tracker without warning can
+read as:
+
+- *"Here are 80 things you've done wrong."*
+- *"Here is 50 hours of homework."*
+- *"I ran a tool I don't fully understand and now you have to triage its output."*
+
+That's not what you mean, but it's how the contact lands when there was no contact before it. A
+maintainer who finds a 80-issue dump in their tracker on Monday morning is most likely to:
+
+1. Close them all without reading.
+2. Burn out a little.
+3. Add the tool to their mental "things that hurt me" list.
+
+Whereas a maintainer who got a 3-paragraph email or a friendly issue first — *"I ran a static-analysis
+tool, found ~80 candidate issues across ~5 categories, would you like to see the report, and if so do
+you prefer one issue per category, an umbrella issue, an email, or a gist?"* — is most likely to
+respond with their actual preference, including sometimes "thanks, but no, I don't have time for this
+right now" (which is a valid answer; respect it).
+
+Maintainer preferences vary widely. Some examples we've seen in practice:
+- *"Please send everything as a single umbrella issue with the full report linked."*
+- *"Please file one GitHub issue per finding with reproducers inline."*
+- *"Please email me the report; I'll triage and file my own issues from it."*
+- *"Thank you, but I'd rather work through these myself; don't open PRs, the report is enough."*
+- *"I can't take on more right now; please re-ask in three months."*
+- *"Use our security policy for anything memory-unsafe."*
+
+You cannot guess which of these applies. **Ask.**
+
+---
+
+## Before you run this tool
+
+A short checklist before kicking off `/cext-review-toolkit:explore`:
+
+- [ ] **Is the project actively maintained?** Last commit, last release, open-issue response time.
+      An archived or barely-maintained extension is rarely worth a full review unless you intend to
+      take over maintenance yourself.
+- [ ] **Read `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`** if they exist. They tell you how
+      the maintainer wants to be contacted, where to file what, and what's off-limits.
+- [ ] **Skim recent commits and the changelog** for fixes that may already address what you'd find.
+      A finding that's already merged on `main` is not a finding.
+- [ ] **Skim the open issues and PRs** for in-flight work in the same area. Build a small
+      known-issues baseline first (`gh issue list`, `gh pr list`, `gh pr diff <N>`) and classify
+      each finding before sharing: `DUPLICATE-FILED` (already in an open issue),
+      `DUPLICATE-FIX-IN-FLIGHT` (covered by an open PR), or `NET-NEW`. cext-review-toolkit's
+      `git-history-analyzer` agent helps surface the recent-fix-completeness angle.
+- [ ] **Check whether there's a security policy.** Memory-safety findings, exploitable buffer overflows,
+      and attacker-controlled-input parsing bugs may belong in private disclosure first.
+- [ ] **Is this a project you're genuinely engaged with?** Reviewing a project you don't actually use
+      or care about, then dropping the report and disappearing, is a particular kind of friction.
+      Maintainers can tell.
+
+If most of those boxes aren't checked, the right move is usually to spend ten minutes on them before
+running the tool, not to skip and run anyway.
+
+---
+
+## Before you share findings
+
+After the tool produces a report:
+
+- [ ] **Pull the latest source and re-verify.** A finding that was real when you cloned can be
+      gone by the time you write it up. Drop fixed-upstream findings; mark them `DONE` in your notes.
+- [ ] **Triage every finding yourself.** This tool produces candidates. Some are false positives.
+      Some are real but not bugs (intentional design choices). Some are real but require maintainer
+      context you don't have. **Don't forward findings you haven't read.**
+- [ ] **Reproduce the FIX-class items you can.** A finding with a runnable reproducer carries far
+      more weight than a static-analysis verdict. The `/cext-review-toolkit:explore` reproducer pass
+      generates these for you, but they need verification on your machine before you cite them.
+- [ ] **Translate severities into the maintainer's vocabulary.** Our `FIX` does not always equal their
+      "must-fix-this-week". Calibrate.
+- [ ] **Check whether what you have is enough to ask, not enough to dump.** A short message with a
+      summary and a link to the report is asking. A 200-line email with 50 inline reproducers is dumping.
+- [ ] **Decide who's actually filing.** If you're using this tool on a colleague's project, the
+      colleague should be the one filing the issues. If it's a public OSS project, you are. Don't
+      cross those wires.
+
+---
+
+## How to reach out — a template
+
+Your first contact should fit in a notification preview. Examples that have worked:
+
+> Hi [maintainer name],
+>
+> I'm Daniel — I maintain [cext-review-toolkit](https://github.com/devdanzin/cext-review-toolkit), a
+> Claude-Code-based static analysis plugin for Python C extensions. I ran it on `<ext>` over the
+> weekend and it surfaced ~N candidate findings across ~K categories (refcount discipline, error
+> paths, NULL safety, …).
+>
+> Would the full report be useful to you, and if so how would you like it? Some maintainers prefer
+> a single umbrella issue, some prefer one issue per category, some would rather have it as an
+> email or a gist. I'm happy to follow your preference. I'm also happy to drop it entirely if it's
+> not a good time.
+>
+> If anything looks security-relevant on first read I'll route it through your security policy
+> rather than the public tracker.
+>
+> The full report is here for reference (private gist): [link]
+>
+> No rush, no pressure.
+>
+> Daniel
+
+Things this template does well:
+- **Identifies who you are and what tool you ran.**
+- **Gives shape (count + categories) without dumping content.**
+- **Offers options instead of choosing for them.**
+- **Preempts the security-disclosure channel.**
+- **Provides an exit ramp** ("happy to drop it entirely") so a "no thanks" is socially easy.
+- **Is short.** Anything longer signals "this will consume a lot of your time".
+
+If you don't have a private channel: open a GitHub Discussion, or open one issue titled something
+like *"Static analysis report — preference for delivery?"* with the same content.
+
+If the maintainer responds, follow their preference exactly. If they don't respond after ~2-3 weeks,
+one polite follow-up is fine; after that, accept silence as "no" and move on.
+
+---
+
+## One issue, umbrella issue, or many?
+
+Once you have the maintainer's preference, follow it. If they didn't specify, here's our default
+heuristic:
+
+| Situation | Recommended shape |
+|---|---|
+| ≤ 3 findings, all FIX-class, all in one area | One issue per finding, each with reproducer |
+| 5-15 findings spanning categories | An **umbrella issue** linking to one sub-issue per finding (the [h5py model](https://github.com/h5py/h5py/issues/2825)) |
+| 15-50 findings | One umbrella issue + the report posted as a gist; ask the maintainer if they want sub-issues filed or if the gist is enough |
+| 50+ findings | Almost always: a gist + a conversation, never a unilateral dump |
+| Free-threading-specific | Often a separate FT-focused report alongside the correctness one |
+| Security-class | **Private disclosure first**, never the public tracker |
+
+The umbrella pattern works because it gives the maintainer a single subscription point, lets them
+close sub-issues incrementally without triage overhead, and makes the report's overall shape visible.
+It also lets external contributors pick up individual sub-issues without having to read the whole
+review.
+
+---
+
+## Calibrating severity
+
+The tool tags every finding `FIX`, `CONSIDER`, `POLICY`, or `ACCEPTABLE`. These are *our* labels;
+maintainers may translate them differently. Some mappings we've seen:
+
+| Our label | Maintainer interpretation (varies) |
+|---|---|
+| **FIX** | "Likely real bug, want a reproducer, will look at this" |
+| **CONSIDER** | "Maybe yes maybe no, depends on whether it matters in practice" |
+| **POLICY** | "My call, not yours; sometimes 'we considered this and chose otherwise' rather than 'good idea, will adopt'" |
+| **ACCEPTABLE** | "OK that the tool noticed, no action needed" |
+
+Don't push back on a maintainer who downgrades or dismisses one of your `FIX` findings. They have
+context you don't — design constraints, performance trade-offs, downstream callers, historical
+incidents. *"We considered that; here's why we left it"* is a valid response, and not a license for
+you to argue.
+
+The single biggest credibility-builder in your communication is being honest when you're uncertain.
+**`SOURCE-ONLY`** findings should be marked as such; **TSan-only races that need specific scheduling**
+should be flagged; **OOM-only crashes that require fault injection** should be labeled. Maintainers
+who see honest uncertainty trust the rest of the report more.
+
+---
+
+## Security findings: responsible disclosure
+
+If your review surfaces something that looks like:
+
+- A buffer overflow or out-of-bounds read on attacker-controlled input
+- A use-after-free reachable from public API or untrusted data
+- A NULL dereference that crashes the host process from external input
+- A parsing bug that breaks input-validator assumptions (the lone-surrogate
+  ujson finding is an example: the C parser silently mutates the string,
+  bypassing a Python-side validator)
+
+then it goes through the project's security disclosure channel **first**, not the public issue tracker.
+In order of preference:
+
+1. The project's `SECURITY.md` instructions (private email, GitHub Security Advisories, dedicated
+   address).
+2. A direct private email to a maintainer if no formal policy exists.
+3. A GitHub Security Advisory draft on the project's repo (if you have permissions).
+
+What "first" means in practice: file the security finding privately, give the maintainer time to
+respond and patch, then — once they're ready — follow their guidance on whether/when/how to discuss
+publicly. The standard 90-day disclosure window is a reasonable default; longer is fine if they ask.
+
+Things to avoid:
+
+- Filing a public issue titled "buffer overflow in `read()`" with a working PoC.
+- Posting the same finding to social media before the maintainer has acknowledged it.
+- Sending a CVE request before the maintainer has had a chance to confirm and patch.
+
+If the maintainer doesn't have a security process and isn't responsive, that itself is a real
+problem; consult upstream guidance ([CERT/CC's coordination guide](https://vuls.cert.org/confluence/display/Wiki/Vulnerability+Disclosure+Policy),
+[OSV's disclosure docs](https://google.github.io/osv.dev/data/#data-sources)) rather than improvising.
+
+---
+
+## PRs: offer, don't push
+
+It is sometimes appropriate to offer a PR alongside a finding. It is rarely appropriate to open
+one before asking.
+
+**Defaults that work:**
+
+- Mention in your initial outreach: *"I'm happy to send PRs for the smaller fixes, or you may prefer
+  to handle them yourself — let me know."*
+- For one-line fixes (typo, missing `Py_DECREF`, missing NULL check) where the patch is unambiguous,
+  it's reasonable to offer a draft PR after the maintainer has acknowledged the finding.
+- For structural changes (multi-phase init migration, abi3 conversion, GC support, FT-readiness), do
+  **not** open a PR without explicit prior agreement on the approach. These are design decisions
+  with multi-week implications.
+- For anything that touches the project's public API, the maintainer decides the API change, not you.
+
+**Real example of a healthy "no thanks":** the ijson maintainer replied to our review with *"Thank you
+very much, honestly, but no — I'd feel better if I addressed these issues myself, in turn learning a bit
+more by doing."* That is a complete, valid answer. The right response is *"absolutely, just let me
+know if you want anything from me."* Not *"are you sure? I have the patches ready."*
+
+If the maintainer accepts your PR, follow their style guide and review process. If they reject your
+PR, accept it. If they want to land their own version of the fix, mention you in the commit, and not
+take your patch — that's also fine; the goal is the bug being fixed, not your name being on it.
+
+---
+
+## After the report is shared
+
+- **Don't ghost.** If the maintainer engages, follow up. If they ask for clarification, provide it.
+  If they take your PR, watch for review comments and respond promptly.
+- **Don't nag.** One follow-up after 2-3 weeks of silence is fine. A second follow-up after another
+  3-4 weeks is the upper limit. After that, accept silence; they may come back to it later or not.
+- **Don't litigate dismissals.** If a maintainer marks something `wontfix` or pushes back on severity,
+  one round of clarification is fine; beyond that, drop it.
+- **Don't summarize on social media without consent.** Posting *"I just found N bugs in $ext using my
+  tool"* before the maintainer has responded is the most common burnout-inducing failure mode.
+  Wait for them to be visible in the conversation, or ask them.
+- **Credit the maintainer in the fix.** If a maintainer takes your finding and ships a patch,
+  thanking them in the issue is normal; mentioning their work positively in any subsequent writeup
+  is normal. Treating them as a passive bug receptacle is not.
+- **Maintain your own reputation.** People talk. A pattern of dropping reports on maintainers who
+  didn't ask for them costs you future credibility on projects that *would* welcome a review.
+
+---
+
+## Anti-patterns
+
+Things we've seen go wrong (sometimes from this tool's users, sometimes adjacent):
+
+- **Auto-filing issues from the report.** The tool produces well-formatted output. It is tempting to
+  pipe the output directly into `gh issue create`. Don't. Every issue should pass through human
+  triage first.
+- **Auto-opening PRs from the suggested fixes.** Same problem, more disruptive.
+- **Dumping a 50-finding report into a 1-maintainer repo.** Especially harmful for solo maintainers
+  with day jobs. Always ask first.
+- **Filing the same review in multiple places** (issue + PR + email + Discord) thinking redundancy
+  helps. It just multiplies the maintainer's triage cost.
+- **Filing security-class findings in the public tracker** because the security policy is annoying
+  to find or use.
+- **Taking offense at dismissals.** A maintainer saying "no, that's intentional" is a complete
+  answer. Don't escalate.
+- **Posting analysis summaries to Twitter / Mastodon / blog before the maintainer has even seen them.**
+  Especially "look how many bugs $ext has" style. Even if true, it punishes the maintainer for being
+  the one who exposed their work to scrutiny.
+- **Writing a "name and shame" thread when a maintainer doesn't respond.** They may be sick, on
+  vacation, or just out of capacity. Silence is not an invitation to escalate publicly.
+- **Generating reports for projects you don't actually use.** This is the #1 sign of "tool is being
+  used as a content farm rather than for genuine engagement."
+- **Leaving the tool's signature in commit messages or PR descriptions verbatim.** Maintainers don't
+  need to read "Co-Authored-By: cext-review-toolkit"; they need to see human judgment in your
+  contribution.
+
+---
+
+## Examples of working well
+
+For reference, three reviews where the engagement worked the way this document describes:
+
+- **ijson** (Rodrigo Tobar / ICRAR): private email first, full report shared as a gist, maintainer
+  declined PRs but accepted the report. Outcome: positive engagement, no churn for the maintainer,
+  fixes will land on his timeline. ([discuss.python.org thread](https://discuss.python.org/t/systematically-finding-bugs-in-python-c-extensions-575-confirmed-so-far/106875),
+  ["Working through reports" reply on the thread](https://discuss.python.org/t/106875/5))
+- **h5py**: review surfaced ~30 findings; rather than filing 30 issues, we opened one umbrella issue
+  ([#2825](https://github.com/h5py/h5py/issues/2825)) linking sub-issues, with the full report
+  attached as a gist. Maintainers triaged at their own pace.
+- **uvloop**: review surfaced FT-readiness gaps; private discussion first about whether the project
+  was actively pursuing FT-safety (it was), TSan-confirmed reproducers shared inline, individual
+  fixes proposed only for the highest-confidence items.
+
+If you're not sure whether your engagement is on this kind of footing, the answer is probably to
+slow down and reach out before sharing more.
+
+---
+
+## When in doubt
+
+Ask yourself: *"If I were the maintainer of this project, and someone I'd never met sent me what I'm
+about to send, would I be glad they did?"*
+
+If yes, send it.
+
+If you can't tell, ask first.
+
+If no, don't send it.

--- a/plugins/cext-review-toolkit/commands/explore.md
+++ b/plugins/cext-review-toolkit/commands/explore.md
@@ -158,6 +158,14 @@ If `parallel` is specified, run agents within each group concurrently (at most `
 
 After all agents complete, perform deduplication, conflict resolution, and produce a unified summary.
 
+> **Before sharing this report externally** (filing issues, opening PRs, sending to a maintainer),
+> point the user at [`WORKING_WITH_MAINTAINERS.md`](../../../WORKING_WITH_MAINTAINERS.md). The
+> short version: a 50-finding report dropped on a maintainer who didn't ask for it is a 50-hour
+> homework assignment. Reach out first, ask what shape they want it in, and don't auto-file or
+> auto-PR. Security findings need responsible disclosure, not a public issue. The synthesis
+> below produces an internal artifact; the question of whether/how to share it with the
+> maintainer is a separate human-judgment step.
+
 #### Deduplication and Conflict Resolution
 
 1. **Merge overlapping findings**: When two agents flag the same file:line, merge them:


### PR DESCRIPTION
## Summary

- Adds **`WORKING_WITH_MAINTAINERS.md`** at the repo root — the primary communication-norms document (ask-don't-dump, outreach templates, severity translation, security disclosure, anti-patterns, working examples).
- **`README.md` revamp** — prominent ⚠️ callout linking to the new doc; agent count corrected (10 → 13 audit + 1 mapper); 2-naive + 1-informed methodology documented; reproducer pass documented; cost-and-time expectations section; Explore Phases table refreshed.
- **`plugins/cext-review-toolkit/commands/explore.md`** — before-sharing caveat in the Phase 3 (Synthesis) section so the audit pipeline doesn't quietly recommend filing N issues.
- **`CHANGELOG.md`** — Documentation entry under `[Unreleased]`.

Scope is intentionally narrow: only files directly tied to the maintainer-communication work. Other untracked content in the tree (multi-chat-workflow.md, writing-actionable-items-lists.md, tsan-data-collection-guide.md, Cython validation docs, pyerfa impact analysis, ft-review-toolkit design docs) will land in separate follow-up PRs.

## Test plan

- [x] No code changes — doc-only PR
- [x] `python -m unittest discover tests -q` still passes (274 tests, no regressions)
- [x] All inter-doc links in the new content resolve to tracked files (no broken cross-references to untracked docs)
- [x] CHANGELOG entry added under `[Unreleased]`

Closes #56

Generated with [Claude Code](https://claude.com/claude-code)